### PR TITLE
Release 1.4.1: Rename delegation flags and events for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.4.1
+
+### Changed
+
+- Renamed `isDelegable` flag to `isConsumerDelegable`
+- Renamed events `EServiceIsDelegableEnabledV2` and `EServiceIsDelegableDisabledV2` to `EServiceIsConsumerDelegableEnabledV2` and `EServiceIsConsumerDelegableDisabledV2`
+
 ## 1.4.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -12,7 +12,7 @@ message EServiceV2 {
   int64 createdAt = 7;
   EServiceModeV2 mode = 8;
   optional bool isSignalHubEnabled = 9;
-  optional bool isDelegable = 10;
+  optional bool isConsumerDelegable = 10;
   optional bool isClientAccessDelegable = 11;
 }
 

--- a/proto/v2/eservice/events.proto
+++ b/proto/v2/eservice/events.proto
@@ -124,11 +124,11 @@ message EServiceDescriptorAttributesUpdatedV2 {
   EServiceV2 eservice = 3;
 }
 
-message EServiceIsDelegableEnabledV2 {
+message EServiceIsConsumerDelegableEnabledV2 {
     EServiceV2 eservice = 2;
 }
 
-message EServiceIsDelegableDisabledV2 {
+message EServiceIsConsumerDelegableDisabledV2 {
     EServiceV2 eservice = 2;
 }
 

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -27,8 +27,8 @@ import {
   EServiceDescriptorAttributesUpdatedV2,
   EServiceIsClientAccessDelegableDisabledV2,
   EServiceIsClientAccessDelegableEnabledV2,
-  EServiceIsDelegableDisabledV2,
-  EServiceIsDelegableEnabledV2,
+  EServiceIsConsumerDelegableDisabledV2,
+  EServiceIsConsumerDelegableEnabledV2,
   EServiceNameUpdatedV2,
 } from "../gen/v2/eservice/events.js";
 
@@ -105,11 +105,11 @@ export function eServiceEventToBinaryDataV2(
     .with({ type: "EServiceDescriptorAttributesUpdated" }, ({ data }) =>
       EServiceDescriptorAttributesUpdatedV2.toBinary(data)
     )
-    .with({ type: "EServiceIsDelegableEnabled" }, ({ data }) =>
-      EServiceIsDelegableEnabledV2.toBinary(data)
+    .with({ type: "EServiceIsConsumerDelegableEnabled" }, ({ data }) =>
+      EServiceIsConsumerDelegableEnabledV2.toBinary(data)
     )
-    .with({ type: "EServiceIsDelegableDisabled" }, ({ data }) =>
-      EServiceIsDelegableDisabledV2.toBinary(data)
+    .with({ type: "EServiceIsConsumerDelegableDisabled" }, ({ data }) =>
+      EServiceIsConsumerDelegableDisabledV2.toBinary(data)
     )
     .with({ type: "EServiceIsClientAccessDelegableEnabled" }, ({ data }) =>
       EServiceIsClientAccessDelegableEnabledV2.toBinary(data)
@@ -310,16 +310,16 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceIsDelegableEnabled"),
-    data: protobufDecoder(EServiceIsDelegableEnabledV2),
+    type: z.literal("EServiceIsConsumerDelegableEnabled"),
+    data: protobufDecoder(EServiceIsConsumerDelegableEnabledV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceIsDelegableDisabled"),
-    data: protobufDecoder(EServiceIsDelegableDisabledV2),
+    type: z.literal("EServiceIsConsumerDelegableDisabled"),
+    data: protobufDecoder(EServiceIsConsumerDelegableDisabledV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),


### PR DESCRIPTION
Rename the `isDelegable` flag and related events to improve clarity and understanding of their purpose.