### PR TITLE
Release 1.4.2: Update DelegationV2 message structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.4.2
+### Updated
+
+- Updated the structure of `delegationV2` message
+
 ## 1.4.1
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/delegation/delegation.proto
+++ b/proto/v2/delegation/delegation.proto
@@ -3,21 +3,19 @@ syntax = "proto3";
 package delegation.v2;
 
 message DelegationV2 {
+  reserved 6, 7, 8, 10;
   string id = 1;
   string delegatorId = 2;
   string delegateId = 3;
   string eserviceId = 4;
   int64 createdAt = 5;
-  int64 submittedAt = 6;
-  optional int64 approvedAt = 7;
-  optional int64 rejectedAt = 8;
   optional string rejectionReason = 9;
-  optional int64 revokedAt = 10;
   DelegationStateV2 state = 11;
   DelegationKindV2 kind = 12;
   DelegationStampsV2 stamps = 13;  
   optional DelegationContractDocumentV2 activationContract = 14;
   optional DelegationContractDocumentV2 revocationContract = 15;
+  optional int64 updatedAt = 16;
 }
 
 message DelegationContractDocumentV2 {


### PR DESCRIPTION
Update the structure of the `DelegationV2` message and increment the version to 1.4.2.