### PR TITLE
Release 1.5.0: Added e-service template events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.5.0
+
+### Added
+
+- Added `EServiceTemplate` data models
+- Added eservice-template events:
+  - `EServiceTemplateAddedV2`
+  - `EServiceTemplateDraftUpdatedV2`
+  - `EServiceTemplateDraftVersionUpdatedV2`
+  - `EServiceTemplateDraftVersionDeletedV2`
+  - `EServiceTemplateDeletedV2`
+  - `EServiceTemplateVersionInterfaceAddedV2`
+  - `EServiceTemplateVersionDocumentAddedV2`
+  - `EServiceTemplateVersionInterfaceDeletedV2`
+  - `EServiceTemplateVersionDocumentDeletedV2`
+  - `EServiceTemplateVersionInterfaceUpdatedV2`
+  - `EServiceTemplateVersionDocumentUpdatedV2`
+  - `EServiceTemplateVersionPublishedV2`
+  - `EServiceTemplateNameUpdatedV2`
+  - `EServiceTemplateIntendedTargetUpdatedV2`
+  - `EServiceTemplateDescriptionUpdatedV2`
+  - `EServiceTemplateVersionQuotasUpdatedV2`
+  - `EServiceTemplateVersionAddedV2`
+  - `EServiceTemplateVersionAttributesUpdatedV2`
+  - `EServiceTemplateVersionSuspendedV2`
+  - `EServiceTemplateVersionActivatedV2`
+- Added eservice events: 
+  - `EServiceDescriptionUpdatedByTemplateUpdateV2`
+  - `EServiceDescriptorQuotasUpdatedByTemplateUpdateV2`
+  - `EServiceDescriptorAttributesUpdatedByTemplateUpdateV2`
+  - `EServiceDescriptorDocumentAddedByTemplateUpdateV2`
+  - `EServiceDescriptorDocumentUpdatedByTemplateUpdateV2`
+  - `EServiceDescriptorDocumentDeletedByTemplateUpdateV2`
+- Updated `EServiceDescriptorV2` data model with optional `templateVersionRef` property
+- Updated `EServiceV2` data model with optional `templateRef` property
+
 ## 1.4.2
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this project will be documented in this file.
   - `EServiceDescriptorDocumentAddedByTemplateUpdateV2`
   - `EServiceDescriptorDocumentUpdatedByTemplateUpdateV2`
   - `EServiceDescriptorDocumentDeletedByTemplateUpdateV2`
+
+### Updated
 - Updated `EServiceDescriptorV2` data model with optional `templateVersionRef` property
 - Updated `EServiceV2` data model with optional `templateRef` property
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/eservice-template/eservice-template.proto
+++ b/proto/v2/eservice-template/eservice-template.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package eservice.template.v2;
+
+import "v2/eservice/eservice.proto";
+
+enum EServiceTemplateVersionStateV2 {
+  DRAFT = 0;
+  PUBLISHED = 1;
+  DEPRECATED = 2;
+  SUSPENDED = 3;
+}
+
+message EServiceTemplateVersionV2 {
+  string id = 1;
+  int64 version = 2;
+  optional string description = 3;
+  repeated eservice.v2.EServiceDocumentV2 docs = 4;
+  EServiceTemplateVersionStateV2 state = 5;
+  optional eservice.v2.EServiceDocumentV2 interface = 6;
+  int32 voucherLifespan = 7;
+  optional int32 dailyCallsPerConsumer = 8;
+  optional int32 dailyCallsTotal = 9;
+  optional eservice.v2.AgreementApprovalPolicyV2 agreementApprovalPolicy = 10;
+  eservice.v2.EServiceAttributesV2 attributes = 11;
+  int64 createdAt = 12;
+  optional int64 publishedAt = 13;
+  optional int64 suspendedAt = 14;
+  optional int64 deprecatedAt = 15;
+}
+
+message EServiceTemplateV2 {
+  string id = 1;
+  string creatorId = 2;
+  string name = 3;
+  string intendedTarget = 4;
+  string description = 5;
+  eservice.v2.EServiceTechnologyV2 technology = 6;
+  repeated EServiceTemplateVersionV2 versions = 7;
+  int64 createdAt = 8;
+  eservice.v2.EServiceModeV2 mode = 9;
+  optional bool isSignalHubEnabled = 10;
+}

--- a/proto/v2/eservice-template/events.proto
+++ b/proto/v2/eservice-template/events.proto
@@ -1,0 +1,106 @@
+syntax = "proto3";
+
+package eservice.template.v2;
+
+import "v2/eservice-template/eservice-template.proto";
+
+message EServiceTemplateAddedV2 {
+  EServiceTemplateV2 eserviceTemplate = 1;
+}
+
+message EServiceTemplateDraftUpdatedV2 {
+  EServiceTemplateV2 eserviceTemplate = 1;
+}
+
+message EServiceTemplateDraftVersionUpdatedV2 {
+  string eserviceTemplateVersionId = 1;
+  EServiceTemplateV2 eserviceTemplate = 2;
+}
+
+message EServiceTemplateDraftVersionDeletedV2 {
+  string eserviceTemplateVersionId = 1;
+  EServiceTemplateV2 eserviceTemplate = 2;
+}
+
+message EServiceTemplateDeletedV2 {
+  EServiceTemplateV2 eserviceTemplate = 1;
+}
+
+message EServiceTemplateVersionInterfaceAddedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionDocumentAddedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionInterfaceDeletedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionDocumentDeletedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionInterfaceUpdatedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionDocumentUpdatedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionPublishedV2 {
+  string eserviceTemplateVersionId = 1;
+  EServiceTemplateV2 eserviceTemplate = 2;
+}
+
+message EServiceTemplateNameUpdatedV2 {
+  EServiceTemplateV2 eserviceTemplate = 1;
+}
+
+message EServiceTemplateIntendedTargetUpdatedV2 {
+  EServiceTemplateV2 eserviceTemplate = 1;
+}
+
+message EServiceTemplateDescriptionUpdatedV2 {
+  EServiceTemplateV2 eserviceTemplate = 1;
+}
+
+message EServiceTemplateVersionQuotasUpdatedV2 {
+  string eserviceTemplateVersionId = 1;
+  EServiceTemplateV2 eserviceTemplate = 2;
+}
+
+message EServiceTemplateVersionAddedV2 {
+  string eserviceTemplateVersionId = 1;
+  EServiceTemplateV2 eserviceTemplate = 2;
+}
+
+message EServiceTemplateVersionAttributesUpdatedV2 {
+  string eserviceTemplateVersionId = 1;
+  repeated string attributeIds = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionSuspendedV2 {
+  string eserviceTemplateVersionId = 1;
+  EServiceTemplateV2 eserviceTemplate = 2;
+}
+
+message EServiceTemplateVersionActivatedV2 {
+  string eserviceTemplateVersionId = 1;
+  EServiceTemplateV2 eserviceTemplate = 2;
+}

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -14,6 +14,12 @@ message EServiceV2 {
   optional bool isSignalHubEnabled = 9;
   optional bool isConsumerDelegable = 10;
   optional bool isClientAccessDelegable = 11;
+  optional EServiceTemplateRefV2 templateRef = 13;
+}
+
+message EServiceTemplateRefV2 {
+  string id = 1;
+  optional string instanceLabel = 2;
 }
 
 message EServiceAttributeValueV2 {
@@ -56,6 +62,21 @@ message EServiceDescriptorV2 {
   optional int64 archivedAt = 17;
   EServiceAttributesV2 attributes = 18;
   repeated DescriptorRejectionReasonV2 rejectionReasons = 19;
+  optional EServiceTemplateVersionRefV2 templateVersionRef = 20;
+}
+
+
+message TemplateInstanceInterfaceMetadataV2 {
+  string contactName = 1;
+  string contactEmail = 2;
+  string contactUrl = 3;
+  string termsAndConditionsUrl = 4;
+  repeated string serverUrls = 5;
+}
+
+message EServiceTemplateVersionRefV2 {
+  string id = 1;
+  optional TemplateInstanceInterfaceMetadataV2 interfaceMetadata = 2;
 }
 
 message EServiceDocumentV2 {

--- a/proto/v2/eservice/events.proto
+++ b/proto/v2/eservice/events.proto
@@ -139,6 +139,44 @@ message EServiceIsClientAccessDelegableEnabledV2 {
 message EServiceIsClientAccessDelegableDisabledV2 {
     EServiceV2 eservice = 2;
 }
+
 message EServiceNameUpdatedV2 {
     EServiceV2 eservice = 1;
+}
+
+message EServiceNameUpdatedByTemplateUpdateV2 {
+    EServiceV2 eservice = 1;
+}
+
+message EServiceDescriptionUpdatedByTemplateUpdateV2 {
+    EServiceV2 eservice = 1;
+}
+
+message EServiceDescriptorQuotasUpdatedByTemplateUpdateV2 {
+  string descriptorId = 1;
+  EServiceV2 eservice = 2;
+}
+
+message EServiceDescriptorAttributesUpdatedByTemplateUpdateV2 {
+  string descriptorId = 1;
+  repeated string attributeIds = 2;
+  EServiceV2 eservice = 3;
+}
+
+message EServiceDescriptorDocumentAddedByTemplateUpdateV2 {
+  string descriptorId = 1;
+  string documentId = 2;
+  EServiceV2 eservice = 3;
+}
+
+message EServiceDescriptorDocumentUpdatedByTemplateUpdateV2 {
+  string descriptorId = 1;
+  string documentId = 2;
+  EServiceV2 eservice = 3;
+}
+
+message EServiceDescriptorDocumentDeletedByTemplateUpdateV2 {
+  string descriptorId = 1;
+  string documentId = 2;
+  EServiceV2 eservice = 3;
 }

--- a/src/eservice-template/eventsV2.ts
+++ b/src/eservice-template/eventsV2.ts
@@ -1,0 +1,257 @@
+import { z } from "zod";
+import { match } from "ts-pattern";
+import {
+  EServiceTemplateVersionActivatedV2,
+  EServiceTemplateAddedV2,
+  EServiceTemplateIntendedTargetUpdatedV2,
+  EServiceTemplateDescriptionUpdatedV2,
+  EServiceTemplateDeletedV2,
+  EServiceTemplateDraftVersionDeletedV2,
+  EServiceTemplateDraftVersionUpdatedV2,
+  EServiceTemplateDraftUpdatedV2,
+  EServiceTemplateNameUpdatedV2,
+  EServiceTemplateVersionSuspendedV2,
+  EServiceTemplateVersionAddedV2,
+  EServiceTemplateVersionAttributesUpdatedV2,
+  EServiceTemplateVersionDocumentAddedV2,
+  EServiceTemplateVersionDocumentDeletedV2,
+  EServiceTemplateVersionDocumentUpdatedV2,
+  EServiceTemplateVersionInterfaceAddedV2,
+  EServiceTemplateVersionInterfaceDeletedV2,
+  EServiceTemplateVersionInterfaceUpdatedV2,
+  EServiceTemplateVersionPublishedV2,
+  EServiceTemplateVersionQuotasUpdatedV2,
+} from "../gen/v2/eservice-template/events.js";
+import { protobufDecoder } from "../utils.js";
+
+export function eserviceTemplateEventToBinaryDataV2(
+  event: EServiceTemplateEventV2
+): Uint8Array {
+  return match(event)
+    .with({ type: "EServiceTemplateVersionActivated" }, ({ data }) =>
+      EServiceTemplateVersionActivatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateAdded" }, ({ data }) =>
+      EServiceTemplateAddedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateIntendedTargetUpdated" }, ({ data }) =>
+      EServiceTemplateIntendedTargetUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateDescriptionUpdated" }, ({ data }) =>
+      EServiceTemplateDescriptionUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateDeleted" }, ({ data }) =>
+      EServiceTemplateDeletedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateDraftVersionDeleted" }, ({ data }) =>
+      EServiceTemplateDraftVersionDeletedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateDraftVersionUpdated" }, ({ data }) =>
+      EServiceTemplateDraftVersionUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateDraftUpdated" }, ({ data }) =>
+      EServiceTemplateDraftUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateNameUpdated" }, ({ data }) =>
+      EServiceTemplateNameUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionSuspended" }, ({ data }) =>
+      EServiceTemplateVersionSuspendedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionAdded" }, ({ data }) =>
+      EServiceTemplateVersionAddedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionAttributesUpdated" }, ({ data }) =>
+      EServiceTemplateVersionAttributesUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionDocumentAdded" }, ({ data }) =>
+      EServiceTemplateVersionDocumentAddedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionDocumentDeleted" }, ({ data }) =>
+      EServiceTemplateVersionDocumentDeletedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionDocumentUpdated" }, ({ data }) =>
+      EServiceTemplateVersionDocumentUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionInterfaceAdded" }, ({ data }) =>
+      EServiceTemplateVersionInterfaceAddedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionInterfaceDeleted" }, ({ data }) =>
+      EServiceTemplateVersionInterfaceDeletedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionInterfaceUpdated" }, ({ data }) =>
+      EServiceTemplateVersionInterfaceUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionPublished" }, ({ data }) =>
+      EServiceTemplateVersionPublishedV2.toBinary(data)
+    )
+    .with({ type: "EServiceTemplateVersionQuotasUpdated" }, ({ data }) =>
+      EServiceTemplateVersionQuotasUpdatedV2.toBinary(data)
+    )
+    .exhaustive();
+}
+
+export const EServiceTemplateEventV2 = z.discriminatedUnion("type", [
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionActivated"),
+    data: protobufDecoder(EServiceTemplateVersionActivatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateAdded"),
+    data: protobufDecoder(EServiceTemplateAddedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateIntendedTargetUpdated"),
+    data: protobufDecoder(EServiceTemplateIntendedTargetUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateDescriptionUpdated"),
+    data: protobufDecoder(EServiceTemplateDescriptionUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateDeleted"),
+    data: protobufDecoder(EServiceTemplateDeletedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateDraftVersionDeleted"),
+    data: protobufDecoder(EServiceTemplateDraftVersionDeletedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateDraftVersionUpdated"),
+    data: protobufDecoder(EServiceTemplateDraftVersionUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateDraftUpdated"),
+    data: protobufDecoder(EServiceTemplateDraftUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateNameUpdated"),
+    data: protobufDecoder(EServiceTemplateNameUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionSuspended"),
+    data: protobufDecoder(EServiceTemplateVersionSuspendedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionAdded"),
+    data: protobufDecoder(EServiceTemplateVersionAddedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionAttributesUpdated"),
+    data: protobufDecoder(EServiceTemplateVersionAttributesUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionDocumentAdded"),
+    data: protobufDecoder(EServiceTemplateVersionDocumentAddedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionDocumentDeleted"),
+    data: protobufDecoder(EServiceTemplateVersionDocumentDeletedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionDocumentUpdated"),
+    data: protobufDecoder(EServiceTemplateVersionDocumentUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionInterfaceAdded"),
+    data: protobufDecoder(EServiceTemplateVersionInterfaceAddedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionInterfaceDeleted"),
+    data: protobufDecoder(EServiceTemplateVersionInterfaceDeletedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionInterfaceUpdated"),
+    data: protobufDecoder(EServiceTemplateVersionInterfaceUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionPublished"),
+    data: protobufDecoder(EServiceTemplateVersionPublishedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceTemplateVersionQuotasUpdated"),
+    data: protobufDecoder(EServiceTemplateVersionQuotasUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+]);
+
+export type EServiceTemplateEventV2 = z.infer<typeof EServiceTemplateEventV2>;

--- a/src/eservice-template/index.ts
+++ b/src/eservice-template/index.ts
@@ -1,0 +1,53 @@
+import { match } from "ts-pattern";
+import { z } from "zod";
+import { VersionedEvent } from "../utils.js";
+import {
+  EServiceTemplateEventV2,
+  eserviceTemplateEventToBinaryDataV2,
+} from "./eventsV2.js";
+
+function eserviceTemplateEventToBinaryData(
+  event: EServiceTemplateEvent
+): Uint8Array {
+  return match(event)
+    .with({ event_version: 2 }, eserviceTemplateEventToBinaryDataV2)
+    .exhaustive();
+}
+
+export function encodeOutboundEServiceTemplateEvent(
+  event: EServiceTemplateEvent
+): string {
+  return JSON.stringify({
+    event_version: event.event_version,
+    type: event.type,
+    data: Buffer.from(eserviceTemplateEventToBinaryData(event)).toString("hex"),
+    stream_id: event.stream_id,
+    version: event.version,
+    timestamp: event.timestamp,
+  });
+}
+
+export function decodeOutboundEServiceTemplateEvent(
+  encodedEvent: string
+): EServiceTemplateEvent {
+  return EServiceTemplateEvent.parse(JSON.parse(encodedEvent));
+}
+
+export const EServiceTemplateEvent = VersionedEvent.transform((obj, ctx) => {
+  const res = match(obj)
+    .with({ event_version: 1 }, () => {
+      throw new Error("Unsupported event version");
+    })
+    .with({ event_version: 2 }, () => EServiceTemplateEventV2.safeParse(obj))
+    .exhaustive();
+
+  if (!res.success) {
+    res.error.issues.forEach(ctx.addIssue);
+    return z.NEVER;
+  }
+  return res.data;
+});
+
+export type EServiceTemplateEventType = EServiceTemplateEvent["type"];
+export type EServiceTemplateEvent = z.infer<typeof EServiceTemplateEvent>;
+export { EServiceTemplateEventV2 };

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -30,6 +30,12 @@ import {
   EServiceIsConsumerDelegableDisabledV2,
   EServiceIsConsumerDelegableEnabledV2,
   EServiceNameUpdatedV2,
+  EServiceDescriptionUpdatedByTemplateUpdateV2,
+  EServiceDescriptorQuotasUpdatedByTemplateUpdateV2,
+  EServiceDescriptorAttributesUpdatedByTemplateUpdateV2,
+  EServiceDescriptorDocumentAddedByTemplateUpdateV2,
+  EServiceDescriptorDocumentUpdatedByTemplateUpdateV2,
+  EServiceDescriptorDocumentDeletedByTemplateUpdateV2,
 } from "../gen/v2/eservice/events.js";
 
 export function eServiceEventToBinaryDataV2(
@@ -119,6 +125,34 @@ export function eServiceEventToBinaryDataV2(
     )
     .with({ type: "EServiceNameUpdated" }, ({ data }) =>
       EServiceNameUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceDescriptionUpdatedByTemplateUpdate" }, ({ data }) =>
+      EServiceDescriptionUpdatedByTemplateUpdateV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorQuotasUpdatedByTemplateUpdate" },
+      ({ data }) =>
+        EServiceDescriptorQuotasUpdatedByTemplateUpdateV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorAttributesUpdatedByTemplateUpdate" },
+      ({ data }) =>
+        EServiceDescriptorAttributesUpdatedByTemplateUpdateV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorDocumentAddedByTemplateUpdate" },
+      ({ data }) =>
+        EServiceDescriptorDocumentAddedByTemplateUpdateV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorDocumentUpdatedByTemplateUpdate" },
+      ({ data }) =>
+        EServiceDescriptorDocumentUpdatedByTemplateUpdateV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorDocumentDeletedByTemplateUpdate" },
+      ({ data }) =>
+        EServiceDescriptorDocumentDeletedByTemplateUpdateV2.toBinary(data)
     )
     .exhaustive();
 }
@@ -344,6 +378,56 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("EServiceIsClientAccessDelegableDisabled"),
     data: protobufDecoder(EServiceIsClientAccessDelegableDisabledV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptionUpdatedByTemplateUpdate"),
+    data: protobufDecoder(EServiceDescriptionUpdatedByTemplateUpdateV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorQuotasUpdatedByTemplateUpdate"),
+    data: protobufDecoder(EServiceDescriptorQuotasUpdatedByTemplateUpdateV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorAttributesUpdatedByTemplateUpdate"),
+    data: protobufDecoder(
+      EServiceDescriptorAttributesUpdatedByTemplateUpdateV2
+    ),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorDocumentAddedByTemplateUpdate"),
+    data: protobufDecoder(EServiceDescriptorDocumentAddedByTemplateUpdateV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorDocumentUpdatedByTemplateUpdate"),
+    data: protobufDecoder(EServiceDescriptorDocumentUpdatedByTemplateUpdateV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorDocumentDeletedByTemplateUpdate"),
+    data: protobufDecoder(EServiceDescriptorDocumentDeletedByTemplateUpdateV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ export * from "./eservice/index.js";
 export * from "./agreement/index.js";
 export * from "./purpose/index.js";
 export * from "./tenant/index.js";
-export * from "./delegation/index.js";
+export * from "./eservice-template/index.js";
+export * from "./eservice-template/index.js";
 
 export * from "./gen/v1/agreement/agreement.js";
 export * from "./gen/v1/agreement/events.js";
@@ -23,3 +24,5 @@ export * from "./gen/v2/tenant/tenant.js";
 export * from "./gen/v2/tenant/events.js";
 export * from "./gen/v2/delegation/delegation.js";
 export * from "./gen/v2/delegation/events.js";
+export * from "./gen/v2/eservice-template/eservice-template.js";
+export * from "./gen/v2/eservice-template/events.js";


### PR DESCRIPTION
- Added `EServiceTemplate` data models
- Added eservice-template events:
  - `EServiceTemplateAddedV2`
  - `EServiceTemplateDraftUpdatedV2`
  - `EServiceTemplateDraftVersionUpdatedV2`
  - `EServiceTemplateDraftVersionDeletedV2`
  - `EServiceTemplateDeletedV2`
  - `EServiceTemplateVersionInterfaceAddedV2`
  - `EServiceTemplateVersionDocumentAddedV2`
  - `EServiceTemplateVersionInterfaceDeletedV2`
  - `EServiceTemplateVersionDocumentDeletedV2`
  - `EServiceTemplateVersionInterfaceUpdatedV2`
  - `EServiceTemplateVersionDocumentUpdatedV2`
  - `EServiceTemplateVersionPublishedV2`
  - `EServiceTemplateNameUpdatedV2`
  - `EServiceTemplateIntendedTargetUpdatedV2`
  - `EServiceTemplateDescriptionUpdatedV2`
  - `EServiceTemplateVersionQuotasUpdatedV2`
  - `EServiceTemplateVersionAddedV2`
  - `EServiceTemplateVersionAttributesUpdatedV2`
  - `EServiceTemplateVersionSuspendedV2`
  - `EServiceTemplateVersionActivatedV2`
- Added eservice events: 
  - `EServiceDescriptionUpdatedByTemplateUpdateV2`
  - `EServiceDescriptorQuotasUpdatedByTemplateUpdateV2`
  - `EServiceDescriptorAttributesUpdatedByTemplateUpdateV2`
  - `EServiceDescriptorDocumentAddedByTemplateUpdateV2`
  - `EServiceDescriptorDocumentUpdatedByTemplateUpdateV2`
  - `EServiceDescriptorDocumentDeletedByTemplateUpdateV2`
- Updated `EServiceDescriptorV2` data model with optional `templateVersionRef` property
- Updated `EServiceV2` data model with optional `templateRef` property


