### PR TITLE
PIN-7836 Remove who from PurposeVersionStamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.6.9
+
+- Removed `who` from `PurposeVersionStamp`
+
 ## 1.6.8
 
 ### Updated

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/purpose/purpose.proto
+++ b/proto/v2/purpose/purpose.proto
@@ -45,6 +45,5 @@ message PurposeVersionStampsV2 {
 }
 
 message PurposeVersionStampV2 {
-  string who = 1;
-  int64 when = 2;
+  int64 when = 1;
 }


### PR DESCRIPTION
This PR removed the `who` field from `PurposeVersionStamp`

Note: this update is safe because the addition of `PurposeVersionStamp` hasn't been used yet.