### PR TITLE
feat: add asyncExchange field to EServiceV2 (PIN-9234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.8.11
+
+### Added
+
+- Added `asyncExchange` in EServiceV2
+
 ## 1.8.10
 ### Feature: instanceLabel - fix
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.10",
+  "version": "1.8.11",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -17,6 +17,7 @@ message EServiceV2 {
   optional string templateId = 13;
   optional bool personalData = 14;
   optional string instanceLabel = 15;
+  optional bool asyncExchange = 16;
 }
 
 message EServiceAttributeValueV2 {

--- a/tests/eservice.test.ts
+++ b/tests/eservice.test.ts
@@ -24,6 +24,7 @@ describe("eservice", () => {
           description: "testtest",
           name: "test",
           technology: EServiceTechnologyV2.REST,
+          asyncExchange: true,
           descriptors: [
             {
               id: "id",


### PR DESCRIPTION
## Summary

- Added `optional bool asyncExchange = 16` to `EServiceV2` protobuf schema
- Bumped version from `1.8.10` → `1.8.11`
- Updated encode/decode round-trip test with `asyncExchange: true`

This enables the interop monorepo to stop stripping the `asyncExchange` flag from outbound events once it upgrades to this version.