### PR TITLE
feature: Outbound Models new archiving fields (PIN-9823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## 1.8.15
 
-### Added archiving scheduled events:
-- `EServiceArchiveScheduleCanceled`
-- `EServiceArchiveScheduled`
-- `EServiceArchiveScheduleCompleted`
-- `EServiceDescriptorArchiveScheduled`
-- `EServiceDescriptorArchiveScheduleCanceled`
-- `EServiceDescriptorArchiveScheduleCompleted`
-
-### Added ArchivingScheduleV2 on EService:
-- Added `ArchivingScheduleV2` on `EService` protobuf model.
-
-### Added ArchivingScopeV2 on EService:
-- Added `ArchivingScopeV2` on `EService` protobuf model.
-
-### Added archivingSchedule on EServiceDescriptorV2:
-- Added `archivingSchedule` property to `EServiceDescriptorV2` on `EService` protobuf model.
-
-### Added archivingReason on EServiceV2:
-- Added `archivingSchedule` property to `EServiceDescriptorV2` on `EServiceV2` protobuf model.
-
-### Added Archiving states on EServiceDescriptorStateV2:
-- Added `ARCHIVING` property to `EServiceDescriptorStateV2` on `EServiceV2` protobuf model.
-- Added `ARCHIVING_SUSPENDED` property to `EServiceDescriptorStateV2` on `EServiceV2` protobuf model.
+### Added
+- Added `ArchivingScheduleV2` message and `ArchivingScopeV2` enum
+- Added `archivingSchedule` property to `EServiceDescriptorV2`
+- Added `archivingReason` property to `EServiceV2`
+- Added `ARCHIVING` and `ARCHIVING_SUSPENDED` states to `EServiceDescriptorStateV2`
+- Added archiving scheduled events:
+  - `EServiceArchiveScheduled`
+  - `EServiceArchiveScheduleCanceled`
+  - `EServiceArchiveScheduleCompleted`
+  - `EServiceDescriptorArchiveScheduled`
+  - `EServiceDescriptorArchiveScheduleCanceled`
+  - `EServiceDescriptorArchiveScheduleCompleted`
 
 ## 1.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ All notable changes to this project will be documented in this file.
 - Added `archivingReason` property to `EServiceV2`
 - Added `ARCHIVING` and `ARCHIVING_SUSPENDED` states to `EServiceDescriptorStateV2`
 - Added archiving scheduled events:
-  - `EServiceArchiveScheduled`
-  - `EServiceArchiveScheduleCanceled`
-  - `EServiceArchiveScheduleCompleted`
-  - `EServiceDescriptorArchiveScheduled`
-  - `EServiceDescriptorArchiveScheduleCanceled`
-  - `EServiceDescriptorArchiveScheduleCompleted`
+  - `EServiceArchivingScheduled`
+  - `EServiceArchivingCanceled`
+  - `EServiceArchivingCompleted`
+  - `EServiceDescriptorArchivingScheduled`
+  - `EServiceDescriptorArchivingCanceled`
+  - `EServiceDescriptorArchivingCompleted`
 
 ## 1.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.8.15
+
+### Added archiving scheduled events:
+- `EServiceArchiveScheduleCanceled`
+- `EServiceArchiveScheduled`
+- `EServiceArchiveScheduleCompleted`
+- `EServiceDescriptorArchiveScheduled`
+- `EServiceDescriptorArchiveScheduleCanceled`
+- `EServiceDescriptorArchiveScheduleCompleted`
+
+### Added ArchivingScheduleV2 on EService:
+- Added `ArchivingScheduleV2` on `EService` protobuf model.
+
+### Added ArchivingScopeV2 on EService:
+- Added `ArchivingScopeV2` on `EService` protobuf model.
+
+### Added archivingSchedule on EServiceDescriptorV2:
+- Added `archivingSchedule` property to `EServiceDescriptorV2` on `EService` protobuf model.
+
+### Added archivingReason on EServiceV2:
+- Added `archivingSchedule` property to `EServiceDescriptorV2` on `EServiceV2` protobuf model.
+
+### Added Archiving states on EServiceDescriptorStateV2:
+- Added `ARCHIVING` property to `EServiceDescriptorStateV2` on `EServiceV2` protobuf model.
+- Added `ARCHIVING_SUSPENDED` property to `EServiceDescriptorStateV2` on `EServiceV2` protobuf model.
+
 ## 1.8.14
 
 ### Renamed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.14",
+  "version": "1.8.15",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.13",
+  "version": "1.8.14",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -17,6 +17,7 @@ message EServiceV2 {
   optional string templateId = 13;
   optional bool personalData = 14;
   optional string instanceLabel = 15;
+  optional string archivingReason = 16;
 }
 
 message EServiceAttributeValueV2 {
@@ -61,6 +62,7 @@ message EServiceDescriptorV2 {
   EServiceAttributesV2 attributes = 18;
   repeated DescriptorRejectionReasonV2 rejectionReasons = 19;
   optional EServiceTemplateVersionRefV2 templateVersionRef = 20;
+  optional ArchivingScheduleV2 archivingSchedule = 21;
 }
 
 
@@ -92,6 +94,8 @@ enum EServiceDescriptorStateV2 {
   SUSPENDED = 3;
   ARCHIVED = 4;
   WAITING_FOR_APPROVAL = 5;
+  ARCHIVING = 6;
+  ARCHIVING_SUSPENDED = 7;
 }
 
 enum EServiceTechnologyV2 {
@@ -107,4 +111,14 @@ enum AgreementApprovalPolicyV2 {
 enum EServiceModeV2 {
   RECEIVE = 0;
   DELIVER = 1;
+}
+
+message ArchivingScheduleV2 {
+  int64 archivableOn = 1;
+  ArchivingScopeV2 scope = 2;
+}
+
+enum ArchivingScopeV2 {
+  ESERVICE = 0;
+  DESCRIPTOR = 1;
 }

--- a/proto/v2/eservice/events.proto
+++ b/proto/v2/eservice/events.proto
@@ -23,15 +23,15 @@ message EServiceClonedV2 {
   EServiceV2 eservice = 3;
 }
 
-message EServiceArchiveScheduledV2 {
+message EServiceArchivingScheduledV2 {
   EServiceV2 eservice = 1;
 }
 
-message EServiceArchiveScheduleCanceledV2 {
+message EServiceArchivingCanceledV2 {
   EServiceV2 eservice = 1;
 }
 
-message EServiceArchiveScheduleCompletedV2 {
+message EServiceArchivingCompletedV2 {
   EServiceV2 eservice = 1;
 }
 
@@ -111,17 +111,17 @@ message EServiceDescriptorDocumentDeletedV2 {
   EServiceV2 eservice = 3;
 }
 
-message EServiceDescriptorArchiveScheduledV2 {
+message EServiceDescriptorArchivingScheduledV2 {
   string descriptorId = 1;
   EServiceV2 eservice = 2;
 }
 
-message EServiceDescriptorArchiveScheduleCanceledV2 {
+message EServiceDescriptorArchivingCanceledV2 {
   string descriptorId = 1;
   EServiceV2 eservice = 2;
 }
 
-message EServiceDescriptorArchiveScheduleCompletedV2 {
+message EServiceDescriptorArchivingCompletedV2 {
   string descriptorId = 1;
   EServiceV2 eservice = 2;
 }

--- a/proto/v2/eservice/events.proto
+++ b/proto/v2/eservice/events.proto
@@ -23,6 +23,18 @@ message EServiceClonedV2 {
   EServiceV2 eservice = 3;
 }
 
+message EServiceArchiveScheduledV2 {
+  EServiceV2 eservice = 1;
+}
+
+message EServiceArchiveScheduleCanceledV2 {
+  EServiceV2 eservice = 1;
+}
+
+message EServiceArchiveScheduleCompletedV2 {
+  EServiceV2 eservice = 1;
+}
+
 message EServiceDescriptorAddedV2 {
   string descriptorId = 1;
   EServiceV2 eservice = 2;
@@ -97,6 +109,21 @@ message EServiceDescriptorDocumentDeletedV2 {
   string descriptorId = 1;
   string documentId = 2;
   EServiceV2 eservice = 3;
+}
+
+message EServiceDescriptorArchiveScheduledV2 {
+  string descriptorId = 1;
+  EServiceV2 eservice = 2;
+}
+
+message EServiceDescriptorArchiveScheduleCanceledV2 {
+  string descriptorId = 1;
+  EServiceV2 eservice = 2;
+}
+
+message EServiceDescriptorArchiveScheduleCompletedV2 {
+  string descriptorId = 1;
+  EServiceV2 eservice = 2;
 }
 
 message EServiceDescriptionUpdatedV2 {

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -44,6 +44,12 @@ import {
   EServicePersonalDataFlagUpdatedByTemplateUpdateV2,
   EServiceInstanceLabelUpdatedV2,
   MaintenanceEServiceUpdatedV2,
+  EServiceArchiveScheduledV2,
+  EServiceArchiveScheduleCanceledV2,
+  EServiceArchiveScheduleCompletedV2,
+  EServiceDescriptorArchiveScheduledV2,
+  EServiceDescriptorArchiveScheduleCanceledV2,
+  EServiceDescriptorArchiveScheduleCompletedV2,
 } from "../gen/v2/eservice/events.js";
 
 export function eServiceEventToBinaryDataV2(
@@ -191,6 +197,26 @@ export function eServiceEventToBinaryDataV2(
     )
     .with({ type: "MaintenanceEServiceUpdated" }, ({ data }) =>
       MaintenanceEServiceUpdatedV2.toBinary(data)
+    )
+    .with({ type: "EServiceDescriptorArchiveScheduled" }, ({ data }) =>
+      EServiceDescriptorArchiveScheduledV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorArchiveScheduleCanceled" },
+      ({ data }) =>
+        EServiceDescriptorArchiveScheduleCanceledV2.toBinary(data)
+    )
+    .with({ type: "EServiceDescriptorArchiveScheduleCompleted" }, ({ data }) =>
+      EServiceDescriptorArchiveScheduleCompletedV2.toBinary(data)
+    )
+    .with({ type: "EServiceArchiveScheduled" }, ({ data }) =>
+      EServiceArchiveScheduledV2.toBinary(data)
+    )
+    .with({ type: "EServiceArchiveScheduleCanceled" }, ({ data }) =>
+      EServiceArchiveScheduleCanceledV2.toBinary(data)
+    )
+    .with({ type: "EServiceArchiveScheduleCompleted" }, ({ data }) =>
+      EServiceArchiveScheduleCompletedV2.toBinary(data)
     )
     .exhaustive();
 }
@@ -530,6 +556,54 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("MaintenanceEServiceUpdated"),
     data: protobufDecoder(MaintenanceEServiceUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorArchiveScheduled"),
+    data: protobufDecoder(EServiceDescriptorArchiveScheduledV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorArchiveScheduleCanceled"),
+    data: protobufDecoder(EServiceDescriptorArchiveScheduleCanceledV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorArchiveScheduleCompleted"),
+    data: protobufDecoder(EServiceDescriptorArchiveScheduleCompletedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceArchiveScheduled"),
+    data: protobufDecoder(EServiceArchiveScheduledV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceArchiveScheduleCanceled"),
+    data: protobufDecoder(EServiceArchiveScheduleCanceledV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceArchiveScheduleCompleted"),
+    data: protobufDecoder(EServiceArchiveScheduleCompletedV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -43,12 +43,12 @@ import {
   EServicePersonalDataFlagUpdatedAfterPublicationV2,
   EServicePersonalDataFlagUpdatedByTemplateUpdateV2,
   EServiceInstanceLabelUpdatedV2,
-  EServiceArchiveScheduledV2,
-  EServiceArchiveScheduleCanceledV2,
-  EServiceArchiveScheduleCompletedV2,
-  EServiceDescriptorArchiveScheduledV2,
-  EServiceDescriptorArchiveScheduleCanceledV2,
-  EServiceDescriptorArchiveScheduleCompletedV2,
+  EServiceDescriptorArchivingScheduledV2,
+  EServiceDescriptorArchivingCanceledV2,
+  EServiceDescriptorArchivingCompletedV2,
+  EServiceArchivingScheduledV2,
+  EServiceArchivingCanceledV2,
+  EServiceArchivingCompletedV2,
   MaintenanceEServicePersonalDataFlagResetV2,
 } from "../gen/v2/eservice/events.js";
 
@@ -198,23 +198,23 @@ export function eServiceEventToBinaryDataV2(
     .with({ type: "MaintenanceEServicePersonalDataFlagReset" }, ({ data }) =>
       MaintenanceEServicePersonalDataFlagResetV2.toBinary(data)
     )
-    .with({ type: "EServiceDescriptorArchiveScheduled" }, ({ data }) =>
-      EServiceDescriptorArchiveScheduledV2.toBinary(data)
+    .with({ type: "EServiceDescriptorArchivingScheduled" }, ({ data }) =>
+      EServiceDescriptorArchivingScheduledV2.toBinary(data)
     )
-    .with({ type: "EServiceDescriptorArchiveScheduleCanceled" }, ({ data }) =>
-      EServiceDescriptorArchiveScheduleCanceledV2.toBinary(data)
+    .with({ type: "EServiceDescriptorArchivingCanceled" }, ({ data }) =>
+      EServiceDescriptorArchivingCanceledV2.toBinary(data)
     )
-    .with({ type: "EServiceDescriptorArchiveScheduleCompleted" }, ({ data }) =>
-      EServiceDescriptorArchiveScheduleCompletedV2.toBinary(data)
+    .with({ type: "EServiceDescriptorArchivingCompleted" }, ({ data }) =>
+      EServiceDescriptorArchivingCompletedV2.toBinary(data)
     )
-    .with({ type: "EServiceArchiveScheduled" }, ({ data }) =>
-      EServiceArchiveScheduledV2.toBinary(data)
+    .with({ type: "EServiceArchivingScheduled" }, ({ data }) =>
+      EServiceArchivingScheduledV2.toBinary(data)
     )
-    .with({ type: "EServiceArchiveScheduleCanceled" }, ({ data }) =>
-      EServiceArchiveScheduleCanceledV2.toBinary(data)
+    .with({ type: "EServiceArchivingCanceled" }, ({ data }) =>
+      EServiceArchivingCanceledV2.toBinary(data)
     )
-    .with({ type: "EServiceArchiveScheduleCompleted" }, ({ data }) =>
-      EServiceArchiveScheduleCompletedV2.toBinary(data)
+    .with({ type: "EServiceArchivingCompleted" }, ({ data }) =>
+      EServiceArchivingCompletedV2.toBinary(data)
     )
     .exhaustive();
 }
@@ -560,48 +560,48 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceDescriptorArchiveScheduled"),
-    data: protobufDecoder(EServiceDescriptorArchiveScheduledV2),
+    type: z.literal("EServiceDescriptorArchivingScheduled"),
+    data: protobufDecoder(EServiceDescriptorArchivingScheduledV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceDescriptorArchiveScheduleCanceled"),
-    data: protobufDecoder(EServiceDescriptorArchiveScheduleCanceledV2),
+    type: z.literal("EServiceDescriptorArchivingCanceled"),
+    data: protobufDecoder(EServiceDescriptorArchivingCanceledV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceDescriptorArchiveScheduleCompleted"),
-    data: protobufDecoder(EServiceDescriptorArchiveScheduleCompletedV2),
+    type: z.literal("EServiceDescriptorArchivingCompleted"),
+    data: protobufDecoder(EServiceDescriptorArchivingCompletedV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceArchiveScheduled"),
-    data: protobufDecoder(EServiceArchiveScheduledV2),
+    type: z.literal("EServiceArchivingScheduled"),
+    data: protobufDecoder(EServiceArchivingScheduledV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceArchiveScheduleCanceled"),
-    data: protobufDecoder(EServiceArchiveScheduleCanceledV2),
+    type: z.literal("EServiceArchivingCanceled"),
+    data: protobufDecoder(EServiceArchivingCanceledV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),
   }),
   z.object({
     event_version: z.literal(2),
-    type: z.literal("EServiceArchiveScheduleCompleted"),
-    data: protobufDecoder(EServiceArchiveScheduleCompletedV2),
+    type: z.literal("EServiceArchivingCompleted"),
+    data: protobufDecoder(EServiceArchivingCompletedV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -201,10 +201,8 @@ export function eServiceEventToBinaryDataV2(
     .with({ type: "EServiceDescriptorArchiveScheduled" }, ({ data }) =>
       EServiceDescriptorArchiveScheduledV2.toBinary(data)
     )
-    .with(
-      { type: "EServiceDescriptorArchiveScheduleCanceled" },
-      ({ data }) =>
-        EServiceDescriptorArchiveScheduleCanceledV2.toBinary(data)
+    .with({ type: "EServiceDescriptorArchiveScheduleCanceled" }, ({ data }) =>
+      EServiceDescriptorArchiveScheduleCanceledV2.toBinary(data)
     )
     .with({ type: "EServiceDescriptorArchiveScheduleCompleted" }, ({ data }) =>
       EServiceDescriptorArchiveScheduleCompletedV2.toBinary(data)


### PR DESCRIPTION
## Issue
- PIN-9823
## Context
This PR adds the new states for **archiving schedule** `(ARCHIVING, ARCHIVING_SUSPENDED)`, new fields for EService  and Descriptor and the new Events.

For more information, please consult the [SRS](https://pagopa.atlassian.net/wiki/spaces/PDNDI/pages/2803302507/DRAFT+SRS+Archiviazione+manuale+e-service#%5BWork-Item-10%5D-Notifiche).
## Scope
- eservice.proto, events.proto
