### PR TITLE
feature: add custom thresholds to m2m (PIN-10057)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.8.17
+
+### Added
+- Added `EServiceDescriptorAttributeDailyCallsPerConsumerUpdatedV2` event to eservice events
+
 ## 1.8.16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/eservice/events.proto
+++ b/proto/v2/eservice/events.proto
@@ -236,3 +236,10 @@ message EServiceInstanceLabelUpdatedV2 {
 message MaintenanceEServicePersonalDataFlagResetV2 {
   EServiceV2 eservice = 1;
 }
+
+message EServiceDescriptorAttributeDailyCallsPerConsumerUpdatedV2 {
+  EServiceV2 eservice = 1;
+  string descriptorId = 2;
+  string attributeId = 3;
+  int32 dailyCallsPerConsumer = 4;
+}

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -33,6 +33,7 @@ import {
   EServiceDescriptionUpdatedByTemplateUpdateV2,
   EServiceDescriptorQuotasUpdatedByTemplateUpdateV2,
   EServiceDescriptorAttributesUpdatedByTemplateUpdateV2,
+  EServiceDescriptorAttributeDailyCallsPerConsumerUpdatedV2,
   EServiceDescriptorDocumentAddedByTemplateUpdateV2,
   EServiceDescriptorDocumentUpdatedByTemplateUpdateV2,
   EServiceDescriptorDocumentDeletedByTemplateUpdateV2,
@@ -170,6 +171,11 @@ export function eServiceEventToBinaryDataV2(
     )
     .with({ type: "EServiceNameUpdatedByTemplateUpdate" }, ({ data }) =>
       EServiceNameUpdatedByTemplateUpdateV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorAttributeDailyCallsPerConsumerUpdated" },
+      ({ data }) =>
+        EServiceDescriptorAttributeDailyCallsPerConsumerUpdatedV2.toBinary(data)
     )
     .with(
       { type: "EServiceDescriptorAgreementApprovalPolicyUpdated" },
@@ -546,6 +552,16 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("EServiceInstanceLabelUpdated"),
     data: protobufDecoder(EServiceInstanceLabelUpdatedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorAttributeDailyCallsPerConsumerUpdated"),
+    data: protobufDecoder(
+      EServiceDescriptorAttributeDailyCallsPerConsumerUpdatedV2
+    ),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),

--- a/tests/eservice.test.ts
+++ b/tests/eservice.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   encodeOutboundEServiceEvent,
   decodeOutboundEServiceEvent,
-  EServiceEvent,
   EServiceModeV2,
   EServiceTechnologyV2,
   EServiceDescriptorStateV2,
   AgreementApprovalPolicyV2,
 } from "../src/index.js";
+import type { EServiceEvent } from "../src/index.js";
 
 describe("eservice", () => {
   it("should correctly encode and decode EServiceDescriptorArchived event", () => {
@@ -60,6 +60,66 @@ describe("eservice", () => {
       stream_id: "123",
       timestamp: new Date(),
       version: 1,
+    };
+
+    const encoded = encodeOutboundEServiceEvent(event);
+    const decoded = decodeOutboundEServiceEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly round-trip EServiceDescriptorAttributeDailyCallsPerConsumerUpdated event with dailyCallsPerConsumer", () => {
+    const event: EServiceEvent = {
+      event_version: 2,
+      type: "EServiceDescriptorAttributeDailyCallsPerConsumerUpdated",
+      data: {
+        descriptorId: "descriptor-id",
+        attributeId: "attribute-id",
+        dailyCallsPerConsumer: 25,
+        eservice: {
+          id: "eservice-id",
+          createdAt: 1n,
+          producerId: "producer-id",
+          mode: EServiceModeV2.DELIVER,
+          description: "test description",
+          name: "test eservice",
+          technology: EServiceTechnologyV2.REST,
+          descriptors: [
+            {
+              id: "descriptor-id",
+              version: 1n,
+              docs: [],
+              state: EServiceDescriptorStateV2.DRAFT,
+              audience: [],
+              voucherLifespan: 60,
+              dailyCallsPerConsumer: 10,
+              dailyCallsTotal: 1000,
+              createdAt: 1n,
+              serverUrls: ["pagopa.it"],
+              agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+              attributes: {
+                certified: [
+                  {
+                    values: [
+                      {
+                        id: "attribute-id",
+                        explicitAttributeVerification: true,
+                        dailyCallsPerConsumer: 25,
+                      },
+                    ],
+                  },
+                ],
+                verified: [],
+                declared: [],
+              },
+              rejectionReasons: [],
+            },
+          ],
+        },
+      },
+      stream_id: "stream-id",
+      timestamp: new Date(),
+      version: 2,
     };
 
     const encoded = encodeOutboundEServiceEvent(event);


### PR DESCRIPTION
## Jira Issue
[PIN-10057](https://pagopa.atlassian.net/browse/PIN-10057)

## Context
- The M2M flow needs outbound event contracts for certified attribute dailyCallsPerConsumer updates on E-Service descriptors.

## Services Affected
- interop-outbound-models

## Key Changes
- Add the EServiceDescriptorAttributeDailyCallsPerConsumerUpdated outbound event contract.
- Update protobuf and TypeScript event definitions for the descriptor-side dailyCallsPerConsumer update.
- Publish metadata remains aligned to version 1.8.17.

## Checklist
- [ ] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [x] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection updated (if required)

[PIN-10057]: https://pagopa.atlassian.net/browse/PIN-10057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ