### PR TITLE
feature: add certified discrete attributes (PIN-9885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - Added `discreteConfig` property to `EServiceTemplateAttributeValueV2`
 - Added `TenantCertifiedDiscreteAttributeV2` with `discreteValue` property
 - Added `certifiedDiscreteAttribute` variant to `TenantAttributeV2`
+- Added `certifiedDiscreteAttributes` property to `AgreementV1`
+- Added `certifiedDiscreteAttributes` property to `AgreementV2`
 
 ## 1.8.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.8.17
+
+### Added support for certified discrete attributes
+
+- Added `AttributeCertifiedDiscreteComparatorV2` enum
+- Added `EServiceAttributeCertifiedDiscreteConfigV2` with `threshold` and `comparator` properties
+- Added `discreteConfig` property to `EServiceAttributeValueV2`
+- Added `discreteConfig` property to `EServiceTemplateAttributeValueV2`
+- Added `TenantCertifiedDiscreteAttributeV2` with `discreteValue` property
+- Added `certifiedDiscreteAttribute` variant to `TenantAttributeV2`
+
 ## 1.8.16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v1/agreement/agreement.proto
+++ b/proto/v1/agreement/agreement.proto
@@ -23,6 +23,7 @@ message AgreementV1 {
   optional StampsV1 stamps = 18;
   optional string rejectionReason = 19;
   optional int64 suspendedAt = 20;
+  repeated CertifiedAttributeV1 certifiedDiscreteAttributes = 21;
 }
 
 message VerifiedAttributeV1 {

--- a/proto/v1/agreement/agreement.proto
+++ b/proto/v1/agreement/agreement.proto
@@ -23,7 +23,8 @@ message AgreementV1 {
   optional StampsV1 stamps = 18;
   optional string rejectionReason = 19;
   optional int64 suspendedAt = 20;
-  repeated CertifiedAttributeV1 certifiedDiscreteAttributes = 21;
+  reserved 21;
+  repeated CertifiedAttributeV1 certifiedDiscreteAttributes = 22;
 }
 
 message VerifiedAttributeV1 {

--- a/proto/v2/agreement/agreement.proto
+++ b/proto/v2/agreement/agreement.proto
@@ -24,6 +24,7 @@ message AgreementV2 {
   optional string rejectionReason = 19;
   optional int64 suspendedAt = 20;
   optional string signedContract = 21;
+  repeated CertifiedAttributeV2 certifiedDiscreteAttributes = 22;
 }
 
 message VerifiedAttributeV2 {

--- a/proto/v2/eservice-template/eservice-template.proto
+++ b/proto/v2/eservice-template/eservice-template.proto
@@ -14,6 +14,7 @@ enum EServiceTemplateVersionStateV2 {
 message EServiceTemplateAttributeValueV2 {
   string id = 1;
   bool explicitAttributeVerification = 2;
+  optional eservice.v2.EServiceAttributeCertifiedDiscreteConfigV2 discreteConfig = 3;
 }
 
 message EServiceTemplateAttributeV2 {

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -20,10 +20,26 @@ message EServiceV2 {
   optional string archivingReason = 16;
 }
 
+enum AttributeCertifiedDiscreteComparatorV2 {
+  UNSPECIFIED = 0;
+  GT = 1;
+  LT = 2;
+  EQ = 3;
+  GTE = 4;
+  LTE = 5;
+  NE = 6;
+}
+
+message EServiceAttributeCertifiedDiscreteConfigV2 {
+  int32 threshold = 1;
+  AttributeCertifiedDiscreteComparatorV2 comparator = 2;
+}
+
 message EServiceAttributeValueV2 {
   string id = 1;
   bool explicitAttributeVerification = 2;
   optional int32 dailyCallsPerConsumer = 3;
+  optional EServiceAttributeCertifiedDiscreteConfigV2 discreteConfig = 4;
 }
 
 message EServiceAttributeV2 {

--- a/proto/v2/tenant/tenant.proto
+++ b/proto/v2/tenant/tenant.proto
@@ -15,6 +15,7 @@ message TenantV2 {
   int64 onboardedAt = 10;
   optional TenantUnitTypeV2 subUnitType = 11;
   optional string selfcareInstitutionType = 12;
+  repeated TenantRemoteIdV2 remoteIds = 14;
 }
 
 enum TenantKindV2 {
@@ -75,6 +76,13 @@ message TenantCertifiedAttributeV2 {
   optional int64 revocationTimestamp = 3;
 }
 
+message TenantCertifiedDiscreteAttributeV2 {
+  string id = 1;
+  int64 assignmentTimestamp = 2;
+  optional int64 revocationTimestamp = 3;
+  int32 discreteValue = 4;
+}
+
 message TenantDeclaredAttributeV2 {
   string id = 1;
   int64 assignmentTimestamp = 2;
@@ -88,10 +96,17 @@ message TenantVerifiedAttributeV2 {
   repeated TenantRevokerV2 revokedBy = 4;
 }
 
+message TenantRemoteIdV2 {
+  string origin = 1;
+  string value = 2;
+  int64 assignmentTimestamp = 3;
+}
+
 message TenantAttributeV2 {
   oneof sealed_value {
     TenantCertifiedAttributeV2 certifiedAttribute = 1;
     TenantDeclaredAttributeV2 declaredAttribute = 2;
     TenantVerifiedAttributeV2 verifiedAttribute = 3;
+    TenantCertifiedDiscreteAttributeV2 certifiedDiscreteAttribute = 4;
   }
 }

--- a/tests/agreement.test.ts
+++ b/tests/agreement.test.ts
@@ -24,5 +24,65 @@ describe("agreement", () => {
     expect(decoded).toEqual(event);
   });
 
-  // TODO: Add more tests for other event types
+  it("should correctly encode and decode AgreementAdded V1 event with certified discrete attributes", () => {
+    const event: AgreementEvent = {
+      event_version: 1,
+      type: "AgreementAdded",
+      data: {
+        agreement: {
+          id: "agreement-id",
+          eserviceId: "eservice-id",
+          descriptorId: "descriptor-id",
+          producerId: "producer-id",
+          consumerId: "consumer-id",
+          state: 1,
+          verifiedAttributes: [],
+          certifiedAttributes: [{ id: "certified-id" }],
+          declaredAttributes: [],
+          consumerDocuments: [],
+          createdAt: 1n,
+          certifiedDiscreteAttributes: [{ id: "certified-discrete-id" }],
+        },
+      },
+      stream_id: "agreement-stream",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundAgreementEvent(event);
+    const decoded = decodeOutboundAgreementEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode AgreementAdded V2 event with certified discrete attributes", () => {
+    const event: AgreementEvent = {
+      event_version: 2,
+      type: "AgreementAdded",
+      data: {
+        agreement: {
+          id: "agreement-id",
+          eserviceId: "eservice-id",
+          descriptorId: "descriptor-id",
+          producerId: "producer-id",
+          consumerId: "consumer-id",
+          state: 1,
+          verifiedAttributes: [],
+          certifiedAttributes: [{ id: "certified-id" }],
+          declaredAttributes: [],
+          consumerDocuments: [],
+          createdAt: 1n,
+          certifiedDiscreteAttributes: [{ id: "certified-discrete-id" }],
+        },
+      },
+      stream_id: "agreement-stream",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundAgreementEvent(event);
+    const decoded = decodeOutboundAgreementEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
 });

--- a/tests/eservice.test.ts
+++ b/tests/eservice.test.ts
@@ -7,6 +7,7 @@ import {
   EServiceTechnologyV2,
   EServiceDescriptorStateV2,
   AgreementApprovalPolicyV2,
+  AttributeCertifiedDiscreteComparatorV2,
 } from "../src/index.js";
 
 describe("eservice", () => {
@@ -45,6 +46,11 @@ describe("eservice", () => {
                         id: "test",
                         explicitAttributeVerification: true,
                         dailyCallsPerConsumer: 10,
+                        discreteConfig: {
+                          threshold: 50,
+                          comparator:
+                            AttributeCertifiedDiscreteComparatorV2.GTE,
+                        },
                       },
                     ],
                   },

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -7,6 +7,7 @@ import {
   EServiceModeV2,
   EServiceTechnologyV2,
   AgreementApprovalPolicyV2,
+  AttributeCertifiedDiscreteComparatorV2,
 } from "../src/index.js";
 
 describe("eservice-template", () => {
@@ -42,6 +43,11 @@ describe("eservice-template", () => {
                       {
                         id: "attr-id",
                         explicitAttributeVerification: false,
+                        discreteConfig: {
+                          threshold: 75,
+                          comparator:
+                            AttributeCertifiedDiscreteComparatorV2.LTE,
+                        },
                       },
                     ],
                   },

--- a/tests/tenant.test.ts
+++ b/tests/tenant.test.ts
@@ -3,6 +3,7 @@ import {
   encodeOutboundTenantEvent,
   decodeOutboundTenantEvent,
   TenantEvent,
+  TenantKindV2,
 } from "../src/index.js";
 
 describe("tenant", () => {
@@ -24,5 +25,52 @@ describe("tenant", () => {
     expect(decoded).toEqual(event);
   });
 
-  // TODO: Add more tests for other event types
+  it("should correctly encode and decode TenantOnboarded event with remote ids and certified discrete attributes", () => {
+    const event: TenantEvent = {
+      event_version: 2,
+      type: "TenantOnboarded",
+      data: {
+        tenant: {
+          id: "tenant-id",
+          selfcareId: "selfcare-id",
+          externalId: {
+            origin: "IPA",
+            value: "tenant-code",
+          },
+          features: [],
+          attributes: [
+            {
+              sealedValue: {
+                oneofKind: "certifiedDiscreteAttribute",
+                certifiedDiscreteAttribute: {
+                  id: "attribute-id",
+                  assignmentTimestamp: 1n,
+                  discreteValue: 42,
+                },
+              },
+            },
+          ],
+          createdAt: 1n,
+          name: "Tenant name",
+          kind: TenantKindV2.PA,
+          onboardedAt: 1n,
+          remoteIds: [
+            {
+              origin: "ANAC",
+              value: "remote-code",
+              assignmentTimestamp: 1n,
+            },
+          ],
+        },
+      },
+      stream_id: "tenant-stream",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundTenantEvent(event);
+    const decoded = decodeOutboundTenantEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
 });


### PR DESCRIPTION
## Jira Issue
[PIN-9885](https://pagopa.atlassian.net/browse/PIN-9885)

## Context
- The SRS introduces certified discrete attributes and requires outbound event models to expose the new certified attribute configuration consistently.

## Services Affected
- interop-outbound-models
- e-service outbound models
- e-service template outbound models
- tenant outbound models

## Key Changes
- Added `AttributeCertifiedDiscreteComparatorV2` and `EServiceAttributeCertifiedDiscreteConfigV2`.
- Added `discreteConfig` to `EServiceAttributeValueV2` and `EServiceTemplateAttributeValueV2`.
- Added `TenantCertifiedDiscreteAttributeV2` and the `certifiedDiscreteAttribute` oneof variant in `TenantAttributeV2`.
- Bumped package version to `1.8.17` and documented the changes in the changelog.
- Added encode/decode tests for certified discrete e-service, e-service template, and tenant payloads.

[PIN-9885]: https://pagopa.atlassian.net/browse/PIN-9885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ