### PR TITLE
refactor(workflows): add step to verify Git tag matches the package.json version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           set -euo pipefail
           
           TAG="${GITHUB_REF_NAME}"
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_VERSION=$(jq -r '.version' ./package.json)
           if [ "$TAG" != "$PACKAGE_VERSION" ]; then
             echo "Tag '$TAG' does not match package.json version '$PACKAGE_VERSION'"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Publish
 on:
   push:
-    branches:
-      - main
-      - "release/*"
+    tags:
+      - "*"
 jobs:
   build:
     environment: npm
@@ -13,6 +12,20 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: Verify tag matches package.json version
+        id: verify-tag-matches-package-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          TAG="${GITHUB_REF_NAME}"
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PACKAGE_VERSION" ]; then
+            echo "Tag '$TAG' does not match package.json version '$PACKAGE_VERSION'"
+            exit 1
+          fi
+
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:
           node-version: '20.x'


### PR DESCRIPTION
This PR removes the `release.yaml` workflow trigger that is activated by push on branches and adds a trigger activated by push on tags.
Moreover, it adds a step to verify that the Git tag matches the package.json version, if not the workflow fails.