### PR TITLE
feat: add PurposeTemplateEServiceTemplate{Linked,Unlinked} events (PIN-10090) & feat: add eservice async exchange events and fields (PIN-9380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added `PurposeTemplateEServiceTemplateLinkedV2` event
 - Added `PurposeTemplateEServiceTemplateUnlinkedV2` event
+- Added `AsyncExchangePropertiesV2` message
+- Added `asyncExchange` property to `EServiceV2` and `EServiceTemplateV2`
+- Added `asyncExchangeCallbackInterface` and `asyncExchangeProperties` properties to `EServiceDescriptorV2` and `EServiceTemplateVersionV2`
+- Added async exchange callback interface events for `EService`:
+  - `EServiceDescriptorAsyncExchangeCallbackInterfaceAdded`
+  - `EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated`
+  - `EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted`
+- Added async exchange callback interface events for `EServiceTemplate`:
+  - `EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded`
+  - `EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated`
+  - `EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeleted`
 
 ## 1.8.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.8.18
+
+### Added
+- Added `PurposeTemplateEServiceTemplateLinkedV2` event
+- Added `PurposeTemplateEServiceTemplateUnlinkedV2` event
+
 ## 1.8.17
 
 ### Restore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "scambi-async_purpose-template-1.0",
+  "version": "scambi-async_purpose-template-1.2",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.17",
+  "version": "scambi-async_purpose-template-1.0",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.18-scambi.async.purpose.template.0",
+  "version": "1.8.18",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "scambi-async_purpose-template-1.2",
+  "version": "1.8.18-scambi.async.purpose.template.0",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/eservice-template/eservice-template.proto
+++ b/proto/v2/eservice-template/eservice-template.proto
@@ -42,6 +42,8 @@ message EServiceTemplateVersionV2 {
   optional int64 publishedAt = 13;
   optional int64 suspendedAt = 14;
   optional int64 deprecatedAt = 15;
+  optional eservice.v2.EServiceDocumentV2 asyncExchangeCallbackInterface = 16;
+  optional eservice.v2.AsyncExchangePropertiesV2 asyncExchangeProperties = 17;
 }
 
 message EServiceTemplateV2 {
@@ -56,4 +58,5 @@ message EServiceTemplateV2 {
   eservice.v2.EServiceModeV2 mode = 9;
   optional bool isSignalHubEnabled = 10;
   optional bool personalData = 11;
+  optional bool asyncExchange = 12;
 }

--- a/proto/v2/eservice-template/events.proto
+++ b/proto/v2/eservice-template/events.proto
@@ -108,3 +108,21 @@ message EServiceTemplateVersionActivatedV2 {
 message EServiceTemplatePersonalDataFlagUpdatedAfterPublicationV2 {
   EServiceTemplateV2 eserviceTemplate = 1;
 }
+
+message EServiceTemplateVersionAsyncExchangeCallbackInterfaceAddedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdatedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}
+
+message EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeletedV2 {
+  string eserviceTemplateVersionId = 1;
+  string documentId = 2;
+  EServiceTemplateV2 eserviceTemplate = 3;
+}

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -17,7 +17,7 @@ message EServiceV2 {
   optional string templateId = 13;
   optional bool personalData = 14;
   optional string instanceLabel = 15;
-  optional bool asyncExchange = 17;
+  optional bool asyncExchange = 16;
 }
 
 message EServiceAttributeValueV2 {
@@ -62,8 +62,8 @@ message EServiceDescriptorV2 {
   EServiceAttributesV2 attributes = 18;
   repeated DescriptorRejectionReasonV2 rejectionReasons = 19;
   optional EServiceTemplateVersionRefV2 templateVersionRef = 20;
-  optional EServiceDocumentV2 asyncExchangeCallbackInterface = 22;
-  optional AsyncExchangePropertiesV2 asyncExchangeProperties = 23;
+  optional EServiceDocumentV2 asyncExchangeCallbackInterface = 21;
+  optional AsyncExchangePropertiesV2 asyncExchangeProperties = 22;
 }
 
 

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -17,6 +17,7 @@ message EServiceV2 {
   optional string templateId = 13;
   optional bool personalData = 14;
   optional string instanceLabel = 15;
+  optional bool asyncExchange = 17;
 }
 
 message EServiceAttributeValueV2 {
@@ -61,6 +62,8 @@ message EServiceDescriptorV2 {
   EServiceAttributesV2 attributes = 18;
   repeated DescriptorRejectionReasonV2 rejectionReasons = 19;
   optional EServiceTemplateVersionRefV2 templateVersionRef = 20;
+  optional EServiceDocumentV2 asyncExchangeCallbackInterface = 22;
+  optional AsyncExchangePropertiesV2 asyncExchangeProperties = 23;
 }
 
 
@@ -74,6 +77,14 @@ message TemplateInstanceInterfaceMetadataV2 {
 message EServiceTemplateVersionRefV2 {
   string id = 1;
   optional TemplateInstanceInterfaceMetadataV2 interfaceMetadata = 2;
+}
+
+message AsyncExchangePropertiesV2 {
+  int32 responseTime = 1;
+  int32 resourceAvailableTime = 2;
+  bool confirmation = 3;
+  bool bulk = 4;
+  int32 maxResultSet = 5;
 }
 
 message EServiceDocumentV2 {

--- a/proto/v2/eservice/events.proto
+++ b/proto/v2/eservice/events.proto
@@ -209,3 +209,21 @@ message EServiceInstanceLabelUpdatedV2 {
 message MaintenanceEServicePersonalDataFlagResetV2 {
   EServiceV2 eservice = 1;
 }
+
+message EServiceDescriptorAsyncExchangeCallbackInterfaceAddedV2 {
+  string descriptorId = 1;
+  string documentId = 2;
+  EServiceV2 eservice = 3;
+}
+
+message EServiceDescriptorAsyncExchangeCallbackInterfaceUpdatedV2 {
+  string descriptorId = 1;
+  string documentId = 2;
+  EServiceV2 eservice = 3;
+}
+
+message EServiceDescriptorAsyncExchangeCallbackInterfaceDeletedV2 {
+  string descriptorId = 1;
+  string documentId = 2;
+  EServiceV2 eservice = 3;
+}

--- a/proto/v2/purpose-template/events.proto
+++ b/proto/v2/purpose-template/events.proto
@@ -4,6 +4,7 @@ package purpose.template.v2;
 
 import "v2/purpose-template/purpose-template.proto";
 import "v2/eservice/eservice.proto";
+import "v2/eservice-template/eservice-template.proto";
 
 message PurposeTemplateAddedV2 {
   PurposeTemplateV2 purposeTemplate = 1;
@@ -20,6 +21,19 @@ message PurposeTemplateEServiceUnlinkedV2 {
   PurposeTemplateV2 purposeTemplate = 1;
   eservice.v2.EServiceV2 eservice = 2;
   string descriptorId = 3;
+}
+
+message PurposeTemplateEServiceTemplateLinkedV2 {
+  PurposeTemplateV2 purposeTemplate = 1;
+  eservice.template.v2.EServiceTemplateV2 eserviceTemplate = 2;
+  string eserviceTemplateVersionId = 3;
+  int64 createdAt = 4;
+}
+
+message PurposeTemplateEServiceTemplateUnlinkedV2 {
+  PurposeTemplateV2 purposeTemplate = 1;
+  eservice.template.v2.EServiceTemplateV2 eserviceTemplate = 2;
+  string eserviceTemplateVersionId = 3;
 }
 
 message PurposeTemplateDraftUpdatedV2 {

--- a/src/eservice-template/eventsV2.ts
+++ b/src/eservice-template/eventsV2.ts
@@ -22,6 +22,9 @@ import {
   EServiceTemplateVersionPublishedV2,
   EServiceTemplateVersionQuotasUpdatedV2,
   EServiceTemplatePersonalDataFlagUpdatedAfterPublicationV2,
+  EServiceTemplateVersionAsyncExchangeCallbackInterfaceAddedV2,
+  EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdatedV2,
+  EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeletedV2,
 } from "../gen/v2/eservice-template/events.js";
 import { protobufDecoder } from "../utils.js";
 
@@ -93,6 +96,27 @@ export function eserviceTemplateEventToBinaryDataV2(
       { type: "EServiceTemplatePersonalDataFlagUpdatedAfterPublication" },
       ({ data }) =>
         EServiceTemplatePersonalDataFlagUpdatedAfterPublicationV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded" },
+      ({ data }) =>
+        EServiceTemplateVersionAsyncExchangeCallbackInterfaceAddedV2.toBinary(
+          data
+        )
+    )
+    .with(
+      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated" },
+      ({ data }) =>
+        EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdatedV2.toBinary(
+          data
+        )
+    )
+    .with(
+      { type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeleted" },
+      ({ data }) =>
+        EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeletedV2.toBinary(
+          data
+        )
     )
     .exhaustive();
 }
@@ -263,6 +287,42 @@ export const EServiceTemplateEventV2 = z.discriminatedUnion("type", [
     type: z.literal("EServiceTemplatePersonalDataFlagUpdatedAfterPublication"),
     data: protobufDecoder(
       EServiceTemplatePersonalDataFlagUpdatedAfterPublicationV2
+    ),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal(
+      "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded"
+    ),
+    data: protobufDecoder(
+      EServiceTemplateVersionAsyncExchangeCallbackInterfaceAddedV2
+    ),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal(
+      "EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated"
+    ),
+    data: protobufDecoder(
+      EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdatedV2
+    ),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal(
+      "EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeleted"
+    ),
+    data: protobufDecoder(
+      EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeletedV2
     ),
     stream_id: z.string(),
     version: z.number(),

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { match } from "ts-pattern";
 import { z } from "zod";
 import { protobufDecoder } from "../utils.js";
@@ -44,6 +45,9 @@ import {
   EServicePersonalDataFlagUpdatedByTemplateUpdateV2,
   EServiceInstanceLabelUpdatedV2,
   MaintenanceEServicePersonalDataFlagResetV2,
+  EServiceDescriptorAsyncExchangeCallbackInterfaceAddedV2,
+  EServiceDescriptorAsyncExchangeCallbackInterfaceUpdatedV2,
+  EServiceDescriptorAsyncExchangeCallbackInterfaceDeletedV2,
 } from "../gen/v2/eservice/events.js";
 
 export function eServiceEventToBinaryDataV2(
@@ -191,6 +195,21 @@ export function eServiceEventToBinaryDataV2(
     )
     .with({ type: "MaintenanceEServicePersonalDataFlagReset" }, ({ data }) =>
       MaintenanceEServicePersonalDataFlagResetV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded" },
+      ({ data }) =>
+        EServiceDescriptorAsyncExchangeCallbackInterfaceAddedV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated" },
+      ({ data }) =>
+        EServiceDescriptorAsyncExchangeCallbackInterfaceUpdatedV2.toBinary(data)
+    )
+    .with(
+      { type: "EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted" },
+      ({ data }) =>
+        EServiceDescriptorAsyncExchangeCallbackInterfaceDeletedV2.toBinary(data)
     )
     .exhaustive();
 }
@@ -530,6 +549,36 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("MaintenanceEServicePersonalDataFlagReset"),
     data: protobufDecoder(MaintenanceEServicePersonalDataFlagResetV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorAsyncExchangeCallbackInterfaceAdded"),
+    data: protobufDecoder(
+      EServiceDescriptorAsyncExchangeCallbackInterfaceAddedV2
+    ),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated"),
+    data: protobufDecoder(
+      EServiceDescriptorAsyncExchangeCallbackInterfaceUpdatedV2
+    ),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted"),
+    data: protobufDecoder(
+      EServiceDescriptorAsyncExchangeCallbackInterfaceDeletedV2
+    ),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),

--- a/src/purpose-template/eventsV2.ts
+++ b/src/purpose-template/eventsV2.ts
@@ -9,6 +9,8 @@ import {
   PurposeTemplateDraftDeletedV2,
   PurposeTemplateDraftUpdatedV2,
   PurposeTemplateEServiceLinkedV2,
+  PurposeTemplateEServiceTemplateLinkedV2,
+  PurposeTemplateEServiceTemplateUnlinkedV2,
   PurposeTemplateEServiceUnlinkedV2,
   PurposeTemplatePublishedV2,
   PurposeTemplateSuspendedV2,
@@ -30,6 +32,12 @@ export function purposeTemplateEventToBinaryDataV2(
     )
     .with({ type: "PurposeTemplateEServiceUnlinked" }, ({ data }) =>
       PurposeTemplateEServiceUnlinkedV2.toBinary(data)
+    )
+    .with({ type: "PurposeTemplateEServiceTemplateLinked" }, ({ data }) =>
+      PurposeTemplateEServiceTemplateLinkedV2.toBinary(data)
+    )
+    .with({ type: "PurposeTemplateEServiceTemplateUnlinked" }, ({ data }) =>
+      PurposeTemplateEServiceTemplateUnlinkedV2.toBinary(data)
     )
     .with({ type: "PurposeTemplateDraftUpdated" }, ({ data }) =>
       PurposeTemplateDraftUpdatedV2.toBinary(data)
@@ -88,6 +96,22 @@ export const PurposeTemplateEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("PurposeTemplateEServiceUnlinked"),
     data: protobufDecoder(PurposeTemplateEServiceUnlinkedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.string(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("PurposeTemplateEServiceTemplateLinked"),
+    data: protobufDecoder(PurposeTemplateEServiceTemplateLinkedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.string(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("PurposeTemplateEServiceTemplateUnlinked"),
+    data: protobufDecoder(PurposeTemplateEServiceTemplateUnlinkedV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.string(),

--- a/tests/eservice.test.ts
+++ b/tests/eservice.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { describe, it, expect } from "vitest";
 import {
   encodeOutboundEServiceEvent,
@@ -49,6 +50,169 @@ describe("eservice", () => {
                     ],
                   },
                 ],
+                verified: [],
+                declared: [],
+              },
+              rejectionReasons: [],
+            },
+          ],
+        },
+      },
+      stream_id: "123",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundEServiceEvent(event);
+    const decoded = decodeOutboundEServiceEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode EServiceDescriptorAsyncExchangeCallbackInterfaceAdded event with all async exchange fields populated", () => {
+    const event: EServiceEvent = {
+      event_version: 2,
+      type: "EServiceDescriptorAsyncExchangeCallbackInterfaceAdded",
+      data: {
+        descriptorId: "descriptor-id",
+        documentId: "callback-doc-id",
+        eservice: {
+          id: "eservice-id",
+          createdAt: 1n,
+          producerId: "producer-id",
+          mode: EServiceModeV2.DELIVER,
+          description: "eservice description",
+          name: "eservice name",
+          technology: EServiceTechnologyV2.REST,
+          asyncExchange: true,
+          descriptors: [
+            {
+              id: "descriptor-id",
+              version: 1n,
+              docs: [],
+              state: EServiceDescriptorStateV2.DRAFT,
+              audience: [],
+              voucherLifespan: 60,
+              dailyCallsPerConsumer: 10,
+              dailyCallsTotal: 1000,
+              createdAt: 1n,
+              serverUrls: ["pagopa.it"],
+              agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+              attributes: {
+                certified: [],
+                verified: [],
+                declared: [],
+              },
+              rejectionReasons: [],
+              asyncExchangeCallbackInterface: {
+                id: "callback-doc-id",
+                name: "callback.yaml",
+                contentType: "application/yaml",
+                checksum: "abc123",
+                uploadDate: "2025-01-01T00:00:00Z",
+                prettyName: "Callback Interface",
+              },
+              asyncExchangeProperties: {
+                responseTime: 5000,
+                resourceAvailableTime: 60000,
+                confirmation: true,
+                bulk: false,
+                maxResultSet: 100,
+              },
+            },
+          ],
+        },
+      },
+      stream_id: "123",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundEServiceEvent(event);
+    const decoded = decodeOutboundEServiceEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated event", () => {
+    const event: EServiceEvent = {
+      event_version: 2,
+      type: "EServiceDescriptorAsyncExchangeCallbackInterfaceUpdated",
+      data: {
+        descriptorId: "descriptor-id",
+        documentId: "callback-doc-id",
+        eservice: {
+          id: "eservice-id",
+          createdAt: 1n,
+          producerId: "producer-id",
+          mode: EServiceModeV2.DELIVER,
+          description: "eservice description",
+          name: "eservice name",
+          technology: EServiceTechnologyV2.REST,
+          descriptors: [
+            {
+              id: "descriptor-id",
+              version: 1n,
+              docs: [],
+              state: EServiceDescriptorStateV2.DRAFT,
+              audience: [],
+              voucherLifespan: 60,
+              dailyCallsPerConsumer: 10,
+              dailyCallsTotal: 1000,
+              createdAt: 1n,
+              serverUrls: ["pagopa.it"],
+              agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+              attributes: {
+                certified: [],
+                verified: [],
+                declared: [],
+              },
+              rejectionReasons: [],
+            },
+          ],
+        },
+      },
+      stream_id: "123",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundEServiceEvent(event);
+    const decoded = decodeOutboundEServiceEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted event", () => {
+    const event: EServiceEvent = {
+      event_version: 2,
+      type: "EServiceDescriptorAsyncExchangeCallbackInterfaceDeleted",
+      data: {
+        descriptorId: "descriptor-id",
+        documentId: "callback-doc-id",
+        eservice: {
+          id: "eservice-id",
+          createdAt: 1n,
+          producerId: "producer-id",
+          mode: EServiceModeV2.DELIVER,
+          description: "eservice description",
+          name: "eservice name",
+          technology: EServiceTechnologyV2.REST,
+          descriptors: [
+            {
+              id: "descriptor-id",
+              version: 1n,
+              docs: [],
+              state: EServiceDescriptorStateV2.DRAFT,
+              audience: [],
+              voucherLifespan: 60,
+              dailyCallsPerConsumer: 10,
+              dailyCallsTotal: 1000,
+              createdAt: 1n,
+              serverUrls: ["pagopa.it"],
+              agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+              attributes: {
+                certified: [],
                 verified: [],
                 declared: [],
               },

--- a/tests/purpose-template.test.ts
+++ b/tests/purpose-template.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeOutboundPurposeTemplateEvent,
+  decodeOutboundPurposeTemplateEvent,
+  PurposeTemplateEvent,
+  PurposeTemplateStateV2,
+  TargetTenantKindV2,
+  EServiceTemplateVersionStateV2,
+  EServiceModeV2,
+  EServiceTechnologyV2,
+  AgreementApprovalPolicyV2,
+} from "../src/index.js";
+
+const purposeTemplate = {
+  id: "purpose-template-id",
+  targetDescription: "Target description",
+  targetTenantKind: TargetTenantKindV2.PA,
+  creatorId: "creator-123",
+  state: PurposeTemplateStateV2.PUBLISHED,
+  createdAt: 1n,
+  purposeTitle: "Purpose title",
+  purposeDescription: "Purpose description",
+  purposeIsFreeOfCharge: true,
+  handlesPersonalData: false,
+};
+
+const eserviceTemplate = {
+  id: "eservice-template-id",
+  creatorId: "creator-123",
+  name: "Test Template",
+  intendedTarget: "Test Target Audience",
+  description: "Test template description",
+  technology: EServiceTechnologyV2.REST,
+  mode: EServiceModeV2.DELIVER,
+  createdAt: 1n,
+  versions: [
+    {
+      id: "version-id",
+      version: 1n,
+      docs: [],
+      state: EServiceTemplateVersionStateV2.PUBLISHED,
+      voucherLifespan: 60,
+      dailyCallsPerConsumer: 10,
+      dailyCallsTotal: 1000,
+      createdAt: 1n,
+      agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+      attributes: {
+        certified: [],
+        verified: [],
+        declared: [],
+      },
+    },
+  ],
+};
+
+describe("purpose-template", () => {
+  it("should correctly encode and decode PurposeTemplateEServiceTemplateLinked event", () => {
+    const event: PurposeTemplateEvent = {
+      event_version: 2,
+      type: "PurposeTemplateEServiceTemplateLinked",
+      data: {
+        purposeTemplate,
+        eserviceTemplate,
+        eserviceTemplateVersionId: "version-id",
+        createdAt: 1n,
+      },
+      stream_id: "123",
+      timestamp: "2026-05-20T12:00:00.000Z",
+      version: 1,
+    };
+
+    const encoded = encodeOutboundPurposeTemplateEvent(event);
+    const decoded = decodeOutboundPurposeTemplateEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode PurposeTemplateEServiceTemplateUnlinked event", () => {
+    const event: PurposeTemplateEvent = {
+      event_version: 2,
+      type: "PurposeTemplateEServiceTemplateUnlinked",
+      data: {
+        purposeTemplate,
+        eserviceTemplate,
+        eserviceTemplateVersionId: "version-id",
+      },
+      stream_id: "123",
+      timestamp: "2026-05-20T12:00:00.000Z",
+      version: 1,
+    };
+
+    const encoded = encodeOutboundPurposeTemplateEvent(event);
+    const decoded = decodeOutboundPurposeTemplateEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+});

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { describe, it, expect } from "vitest";
 import {
   encodeOutboundEServiceTemplateEvent,
@@ -46,6 +47,163 @@ describe("eservice-template", () => {
                     ],
                   },
                 ],
+                verified: [],
+                declared: [],
+              },
+            },
+          ],
+        },
+      },
+      stream_id: "123",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundEServiceTemplateEvent(event);
+    const decoded = decodeOutboundEServiceTemplateEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded event with all async exchange fields populated", () => {
+    const event: EServiceTemplateEvent = {
+      event_version: 2,
+      type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceAdded",
+      data: {
+        eserviceTemplateVersionId: "version-id",
+        documentId: "callback-doc-id",
+        eserviceTemplate: {
+          id: "template-id",
+          creatorId: "creator-123",
+          name: "Test Template",
+          intendedTarget: "Test Target Audience",
+          description: "Test template description",
+          technology: EServiceTechnologyV2.REST,
+          mode: EServiceModeV2.DELIVER,
+          createdAt: 1n,
+          asyncExchange: true,
+          versions: [
+            {
+              id: "version-id",
+              version: 1n,
+              docs: [],
+              state: EServiceTemplateVersionStateV2.DRAFT,
+              voucherLifespan: 60,
+              dailyCallsPerConsumer: 10,
+              dailyCallsTotal: 1000,
+              createdAt: 1n,
+              agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+              attributes: {
+                certified: [],
+                verified: [],
+                declared: [],
+              },
+              asyncExchangeCallbackInterface: {
+                id: "callback-doc-id",
+                name: "callback.yaml",
+                contentType: "application/yaml",
+                checksum: "abc123",
+                uploadDate: "2025-01-01T00:00:00Z",
+                prettyName: "Callback Interface",
+              },
+              asyncExchangeProperties: {
+                responseTime: 5000,
+                resourceAvailableTime: 60000,
+                confirmation: true,
+                bulk: false,
+                maxResultSet: 100,
+              },
+            },
+          ],
+        },
+      },
+      stream_id: "123",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundEServiceTemplateEvent(event);
+    const decoded = decodeOutboundEServiceTemplateEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated event", () => {
+    const event: EServiceTemplateEvent = {
+      event_version: 2,
+      type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceUpdated",
+      data: {
+        eserviceTemplateVersionId: "version-id",
+        documentId: "callback-doc-id",
+        eserviceTemplate: {
+          id: "template-id",
+          creatorId: "creator-123",
+          name: "Test Template",
+          intendedTarget: "Test Target Audience",
+          description: "Test template description",
+          technology: EServiceTechnologyV2.REST,
+          mode: EServiceModeV2.DELIVER,
+          createdAt: 1n,
+          versions: [
+            {
+              id: "version-id",
+              version: 1n,
+              docs: [],
+              state: EServiceTemplateVersionStateV2.DRAFT,
+              voucherLifespan: 60,
+              dailyCallsPerConsumer: 10,
+              dailyCallsTotal: 1000,
+              createdAt: 1n,
+              agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+              attributes: {
+                certified: [],
+                verified: [],
+                declared: [],
+              },
+            },
+          ],
+        },
+      },
+      stream_id: "123",
+      timestamp: new Date(),
+      version: 1,
+    };
+
+    const encoded = encodeOutboundEServiceTemplateEvent(event);
+    const decoded = decodeOutboundEServiceTemplateEvent(encoded);
+
+    expect(decoded).toEqual(event);
+  });
+
+  it("should correctly encode and decode EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeleted event", () => {
+    const event: EServiceTemplateEvent = {
+      event_version: 2,
+      type: "EServiceTemplateVersionAsyncExchangeCallbackInterfaceDeleted",
+      data: {
+        eserviceTemplateVersionId: "version-id",
+        documentId: "callback-doc-id",
+        eserviceTemplate: {
+          id: "template-id",
+          creatorId: "creator-123",
+          name: "Test Template",
+          intendedTarget: "Test Target Audience",
+          description: "Test template description",
+          technology: EServiceTechnologyV2.REST,
+          mode: EServiceModeV2.DELIVER,
+          createdAt: 1n,
+          versions: [
+            {
+              id: "version-id",
+              version: 1n,
+              docs: [],
+              state: EServiceTemplateVersionStateV2.DRAFT,
+              voucherLifespan: 60,
+              dailyCallsPerConsumer: 10,
+              dailyCallsTotal: 1000,
+              createdAt: 1n,
+              agreementApprovalPolicy: AgreementApprovalPolicyV2.AUTOMATIC,
+              attributes: {
+                certified: [],
                 verified: [],
                 declared: [],
               },


### PR DESCRIPTION
Add `PurposeTemplateEServiceTemplateLinkedV2` and `PurposeTemplateEServiceTemplateUnlinkedV2` events for the link between purpose template and e-service template.

[PIN-10090](https://pagopa.atlassian.net/browse/PIN-10090)

---

- Add async exchange fields to outbound proto: `asyncExchange` flag on `EServiceV2`/`EServiceTemplateV2`, `asyncExchangeCallbackInterface` + `asyncExchangeProperties` on `EServiceDescriptorV2`/`EServiceTemplateVersionV2`, plus new `AsyncExchangePropertiesV2` message.
- Add the 3 catalog + 3 template `*AsyncExchangeCallbackInterface{Added,Updated,Deleted}V2` events.
- Encode/decode tests for all 6 new events.

[PIN-9380](https://pagopa.atlassian.net/browse/PIN-9380)





[PIN-10090]: https://pagopa.atlassian.net/browse/PIN-10090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PIN-9380]: https://pagopa.atlassian.net/browse/PIN-9380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ