### PR TITLE
reverting changes about eservice manual archiving, to restore correct feature order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## 1.8.16
+## 1.8.17
 
-### Added
-- Added `startedAt` property to `ArchivingScheduleV2`
-
-## 1.8.15
-
-### Added
-- Added `ArchivingScheduleV2` message and `ArchivingScopeV2` enum
-- Added `archivingSchedule` property to `EServiceDescriptorV2`
-- Added `archivingReason` property to `EServiceV2`
-- Added `ARCHIVING` and `ARCHIVING_SUSPENDED` states to `EServiceDescriptorStateV2`
-- Added archiving scheduled events:
-  - `EServiceArchivingScheduled`
-  - `EServiceArchivingCanceled`
-  - `EServiceArchivingCompleted`
-  - `EServiceDescriptorArchivingScheduled`
-  - `EServiceDescriptorArchivingCanceled`
-  - `EServiceDescriptorArchivingCompleted`
+### Restore
+- Revert recent changes to ensure stability
 
 ## 1.8.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to this project will be documented in this file.
 ### Restore
 - Revert recent changes to ensure stability
 
+## 1.8.16
+
+### Added
+- Added `startedAt` property to `ArchivingScheduleV2`
+
+## 1.8.15
+
+### Added
+- Added `ArchivingScheduleV2` message and `ArchivingScopeV2` enum
+- Added `archivingSchedule` property to `EServiceDescriptorV2`
+- Added `archivingReason` property to `EServiceV2`
+- Added `ARCHIVING` and `ARCHIVING_SUSPENDED` states to `EServiceDescriptorStateV2`
+- Added archiving scheduled events:
+  - `EServiceArchivingScheduled`
+  - `EServiceArchivingCanceled`
+  - `EServiceArchivingCompleted`
+  - `EServiceDescriptorArchivingScheduled`
+  - `EServiceDescriptorArchivingCanceled`
+  - `EServiceDescriptorArchivingCompleted`
+
 ## 1.8.14
 
 ### Renamed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/eservice/eservice.proto
+++ b/proto/v2/eservice/eservice.proto
@@ -17,7 +17,6 @@ message EServiceV2 {
   optional string templateId = 13;
   optional bool personalData = 14;
   optional string instanceLabel = 15;
-  optional string archivingReason = 16;
 }
 
 message EServiceAttributeValueV2 {
@@ -62,7 +61,6 @@ message EServiceDescriptorV2 {
   EServiceAttributesV2 attributes = 18;
   repeated DescriptorRejectionReasonV2 rejectionReasons = 19;
   optional EServiceTemplateVersionRefV2 templateVersionRef = 20;
-  optional ArchivingScheduleV2 archivingSchedule = 21;
 }
 
 
@@ -94,8 +92,6 @@ enum EServiceDescriptorStateV2 {
   SUSPENDED = 3;
   ARCHIVED = 4;
   WAITING_FOR_APPROVAL = 5;
-  ARCHIVING = 6;
-  ARCHIVING_SUSPENDED = 7;
 }
 
 enum EServiceTechnologyV2 {
@@ -111,15 +107,4 @@ enum AgreementApprovalPolicyV2 {
 enum EServiceModeV2 {
   RECEIVE = 0;
   DELIVER = 1;
-}
-
-message ArchivingScheduleV2 {
-  int64 archivableOn = 1;
-  ArchivingScopeV2 scope = 2;
-  int64 startedAt = 3;
-}
-
-enum ArchivingScopeV2 {
-  ESERVICE = 0;
-  DESCRIPTOR = 1;
 }

--- a/proto/v2/eservice/events.proto
+++ b/proto/v2/eservice/events.proto
@@ -23,18 +23,6 @@ message EServiceClonedV2 {
   EServiceV2 eservice = 3;
 }
 
-message EServiceArchivingScheduledV2 {
-  EServiceV2 eservice = 1;
-}
-
-message EServiceArchivingCanceledV2 {
-  EServiceV2 eservice = 1;
-}
-
-message EServiceArchivingCompletedV2 {
-  EServiceV2 eservice = 1;
-}
-
 message EServiceDescriptorAddedV2 {
   string descriptorId = 1;
   EServiceV2 eservice = 2;
@@ -109,21 +97,6 @@ message EServiceDescriptorDocumentDeletedV2 {
   string descriptorId = 1;
   string documentId = 2;
   EServiceV2 eservice = 3;
-}
-
-message EServiceDescriptorArchivingScheduledV2 {
-  string descriptorId = 1;
-  EServiceV2 eservice = 2;
-}
-
-message EServiceDescriptorArchivingCanceledV2 {
-  string descriptorId = 1;
-  EServiceV2 eservice = 2;
-}
-
-message EServiceDescriptorArchivingCompletedV2 {
-  string descriptorId = 1;
-  EServiceV2 eservice = 2;
 }
 
 message EServiceDescriptionUpdatedV2 {

--- a/src/eservice/eventsV2.ts
+++ b/src/eservice/eventsV2.ts
@@ -43,12 +43,6 @@ import {
   EServicePersonalDataFlagUpdatedAfterPublicationV2,
   EServicePersonalDataFlagUpdatedByTemplateUpdateV2,
   EServiceInstanceLabelUpdatedV2,
-  EServiceDescriptorArchivingScheduledV2,
-  EServiceDescriptorArchivingCanceledV2,
-  EServiceDescriptorArchivingCompletedV2,
-  EServiceArchivingScheduledV2,
-  EServiceArchivingCanceledV2,
-  EServiceArchivingCompletedV2,
   MaintenanceEServicePersonalDataFlagResetV2,
 } from "../gen/v2/eservice/events.js";
 
@@ -197,24 +191,6 @@ export function eServiceEventToBinaryDataV2(
     )
     .with({ type: "MaintenanceEServicePersonalDataFlagReset" }, ({ data }) =>
       MaintenanceEServicePersonalDataFlagResetV2.toBinary(data)
-    )
-    .with({ type: "EServiceDescriptorArchivingScheduled" }, ({ data }) =>
-      EServiceDescriptorArchivingScheduledV2.toBinary(data)
-    )
-    .with({ type: "EServiceDescriptorArchivingCanceled" }, ({ data }) =>
-      EServiceDescriptorArchivingCanceledV2.toBinary(data)
-    )
-    .with({ type: "EServiceDescriptorArchivingCompleted" }, ({ data }) =>
-      EServiceDescriptorArchivingCompletedV2.toBinary(data)
-    )
-    .with({ type: "EServiceArchivingScheduled" }, ({ data }) =>
-      EServiceArchivingScheduledV2.toBinary(data)
-    )
-    .with({ type: "EServiceArchivingCanceled" }, ({ data }) =>
-      EServiceArchivingCanceledV2.toBinary(data)
-    )
-    .with({ type: "EServiceArchivingCompleted" }, ({ data }) =>
-      EServiceArchivingCompletedV2.toBinary(data)
     )
     .exhaustive();
 }
@@ -554,54 +530,6 @@ export const EServiceEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("MaintenanceEServicePersonalDataFlagReset"),
     data: protobufDecoder(MaintenanceEServicePersonalDataFlagResetV2),
-    stream_id: z.string(),
-    version: z.number(),
-    timestamp: z.coerce.date(),
-  }),
-  z.object({
-    event_version: z.literal(2),
-    type: z.literal("EServiceDescriptorArchivingScheduled"),
-    data: protobufDecoder(EServiceDescriptorArchivingScheduledV2),
-    stream_id: z.string(),
-    version: z.number(),
-    timestamp: z.coerce.date(),
-  }),
-  z.object({
-    event_version: z.literal(2),
-    type: z.literal("EServiceDescriptorArchivingCanceled"),
-    data: protobufDecoder(EServiceDescriptorArchivingCanceledV2),
-    stream_id: z.string(),
-    version: z.number(),
-    timestamp: z.coerce.date(),
-  }),
-  z.object({
-    event_version: z.literal(2),
-    type: z.literal("EServiceDescriptorArchivingCompleted"),
-    data: protobufDecoder(EServiceDescriptorArchivingCompletedV2),
-    stream_id: z.string(),
-    version: z.number(),
-    timestamp: z.coerce.date(),
-  }),
-  z.object({
-    event_version: z.literal(2),
-    type: z.literal("EServiceArchivingScheduled"),
-    data: protobufDecoder(EServiceArchivingScheduledV2),
-    stream_id: z.string(),
-    version: z.number(),
-    timestamp: z.coerce.date(),
-  }),
-  z.object({
-    event_version: z.literal(2),
-    type: z.literal("EServiceArchivingCanceled"),
-    data: protobufDecoder(EServiceArchivingCanceledV2),
-    stream_id: z.string(),
-    version: z.number(),
-    timestamp: z.coerce.date(),
-  }),
-  z.object({
-    event_version: z.literal(2),
-    type: z.literal("EServiceArchivingCompleted"),
-    data: protobufDecoder(EServiceArchivingCompletedV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),


### PR DESCRIPTION

## Description
This PR restores the `main` branch to a stable and consistent state by removing support for manual archiving events that were introduced in versions `1.8.15` and `1.8.16`.

##  Changes Introduced
* **Revert:** Removed all code and logic related to manual archiving management.
* **Version Bump:** Upgraded the package version to `1.8.17`, which will become the new `latest` stable release on npm.

##  Notes for Future Development
* The `main` branch is now clean and ready to serve as a reliable baseline for upcoming features.
* Work on manual archiving events is not discarded; it will be handled moving forward through our standard feature branch workflow.

See [compare](https://github.com/pagopa/interop-outbound-models/compare/b384522bcb617006a9a918b69fbdfcd7e7c0fa22...revert-commit-about-eservice-manual-archiving) between last stable commit and this reverted branch
