### PR TITLE
feature: add MaintenanceTenantRemoteIdDeleted event to Tenant (PIN-10022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## 1.8.18.attributi-certificati-discreti
 
+### 1.8.18.attributi-certificati-discreti.3
+
+- Added `MaintenanceTenantRemoteIdDeletedV2` message to `TenantEventV2`
+
 ### 1.8.18.attributi-certificati-discreti.2
 
 - Removed `certifiedDiscreteAttributes` field number 22 from `AgreementV1` protobuf model

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/interop-outbound-models",
-  "version": "1.8.18-attributi.certificati.discreti.2",
+  "version": "1.8.18-attributi.certificati.discreti.3",
   "description": "PagoPA Interoperability outbound models",
   "main": "dist",
   "type": "module",

--- a/proto/v2/tenant/events.proto
+++ b/proto/v2/tenant/events.proto
@@ -104,3 +104,7 @@ message TenantCertifiedDiscreteAttributeUpdatedV2 {
 message TenantRemoteIdAssignedV2 {
   TenantV2 tenant = 1;
 }
+
+message MaintenanceTenantRemoteIdDeletedV2 {
+  TenantV2 tenant = 1;
+}

--- a/src/tenant/eventsV2.ts
+++ b/src/tenant/eventsV2.ts
@@ -23,6 +23,7 @@ import {
   TenantCertifiedDiscreteAttributeRevokedV2,
   TenantCertifiedDiscreteAttributeUpdatedV2,
   TenantRemoteIdAssignedV2,
+  MaintenanceTenantRemoteIdDeletedV2,
 } from "../gen/v2/tenant/events.js";
 import { protobufDecoder } from "../utils.js";
 
@@ -93,6 +94,9 @@ export function tenantEventToBinaryDataV2(event: TenantEventV2): Uint8Array {
     )
     .with({ type: "TenantRemoteIdAssigned" }, ({ data }) =>
       TenantRemoteIdAssignedV2.toBinary(data)
+    )
+    .with({ type: "MaintenanceTenantRemoteIdDeleted" }, ({ data }) =>
+      MaintenanceTenantRemoteIdDeletedV2.toBinary(data)
     )
     .exhaustive();
 }
@@ -270,6 +274,14 @@ export const TenantEventV2 = z.discriminatedUnion("type", [
     event_version: z.literal(2),
     type: z.literal("TenantRemoteIdAssigned"),
     data: protobufDecoder(TenantRemoteIdAssignedV2),
+    stream_id: z.string(),
+    version: z.number(),
+    timestamp: z.coerce.date(),
+  }),
+  z.object({
+    event_version: z.literal(2),
+    type: z.literal("MaintenanceTenantRemoteIdDeleted"),
+    data: protobufDecoder(MaintenanceTenantRemoteIdDeletedV2),
     stream_id: z.string(),
     version: z.number(),
     timestamp: z.coerce.date(),


### PR DESCRIPTION
## Description

Adds the new `MaintenanceTenantRemoteIdDeletedV2` message to `TenantEventV2`, needed by the tenant-process maintenance API that removes a `TenantRemoteId` from a tenant (PIN-10022).

## Changes
- `proto/v2/tenant/events.proto`: new `MaintenanceTenantRemoteIdDeletedV2 { TenantV2 tenant = 1; }`
- `src/tenant/eventsV2.ts`: registered in `tenantEventToBinaryDataV2` and `TenantEventV2` union